### PR TITLE
Add scripts to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,12 @@
     "ts-node": "^4.0.0",
     "tslint": "^5.8.0",
     "typescript": "^2.6.2"
+  },
+  "scripts": {
+    "compile-tests": "bin/compile-tests",
+    "compile-typings": "bin/compile-typings",
+    "console": "bin/console",
+    "test": "bin/test",
+    "testrpc": "bin/testrpc"
   }
 }


### PR DESCRIPTION
You could now run tests using NPM or Yarn scripts in `package.json`. There is also support for other scripts in `bin` directory.

```bash
npm test
yarn test
```