### PR TITLE
Remove public type Ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,8 +267,6 @@ const getFormattedTypedDataAddAddress = (
       EIP712Domain: [
           { name: 'name', type: 'string' },
           { name: 'version', type: 'string' },
-          { name: 'chainId', type: 'uint256' },
-          { name: 'verifyingContract', type: 'address' },
       ],
       AddAddress: [
         { name: 'sender', type: 'address'},
@@ -279,10 +277,6 @@ const getFormattedTypedDataAddAddress = (
     domain: {
       name: 'Bloom',
       version: '1',
-      // Rinkeby
-      chainId: 4,
-      // Dummy contract address for testing
-      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
     },
     message: {
       sender: sender,
@@ -411,21 +405,17 @@ Recover Signer returns the address of the user who signed a message.
 Each signature contains a domain specification so the user understands how their signature will be used. The domain specifies the dApp name, version, chain Id and the contract intended to use the signatures.
 ```
   bytes32 constant EIP712DOMAIN_TYPEHASH = keccak256(
-    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    "EIP712Domain(string name,string version)"
   );
 
   bytes32 DOMAIN_SEPARATOR = hash(EIP712Domain({
       name: "Bloom",
       version: '1',
-      chainId: 4, // Rinkeby
-      verifyingContract: this
     }));
 
   struct EIP712Domain {
       string  name;
       string  version;
-      uint256 chainId;
-      address verifyingContract;
   }
 
   function hash(EIP712Domain eip712Domain) internal pure returns (bytes32) {
@@ -433,8 +423,6 @@ Each signature contains a domain specification so the user understands how their
       EIP712DOMAIN_TYPEHASH,
       keccak256(bytes(eip712Domain.name)),
       keccak256(bytes(eip712Domain.version)),
-      eip712Domain.chainId,
-      eip712Domain.verifyingContract
     ));
   }
 ```
@@ -489,8 +477,6 @@ export const getFormattedTypedDataAddAddress = (
       EIP712Domain: [
           { name: 'name', type: 'string' },
           { name: 'version', type: 'string' },
-          { name: 'chainId', type: 'uint256' },
-          { name: 'verifyingContract', type: 'address' },
       ],
       AddAddress: [
         { name: 'sender', type: 'address'},
@@ -501,10 +487,6 @@ export const getFormattedTypedDataAddAddress = (
     domain: {
       name: 'Bloom',
       version: '1',
-      // Rinkeby
-      chainId: 4,
-      // Dummy contract address for testing
-      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
     },
     message: {
       sender: sender,
@@ -645,7 +627,7 @@ During an active stake, *AttestationRepo* is the token holder of the collaterali
 ```
 # Attestation Logic
 ## Event Based Storage For Attestations
-Event based storage is preferable to EVM state storage for variables not critical to the contract logic in order to save a significant amount of gas. Events are just as permanent as contract storage, they just cannot be referenced from within a transaction. Attestation data such as dataHash, typeIds and requesterId are not critical to the logic of the contract. However they are critical to the Bloom Protocol. They are stored by emitting an event at the time of an attestation.
+Event based storage is preferable to EVM state storage for variables not critical to the contract logic in order to save a significant amount of gas. Events are just as permanent as contract storage, they just cannot be referenced from within a transaction. Attestation data such as dataHash and requesterId are not critical to the logic of the contract. However they are critical to the Bloom Protocol. They are stored by emitting an event at the time of an attestation.
 ```
   event TraitAttested(
     uint256 attestationId,
@@ -653,7 +635,6 @@ Event based storage is preferable to EVM state storage for variables not critica
     uint256 attesterId,
     uint256 requesterId,
     bytes32 dataHash,
-    uint256[] typeIds,
     uint256 stakeValue,
     uint256 expiresAt
     );
@@ -671,29 +652,18 @@ Attestations may reference a single type of identity data or a group of data. Th
   type: 'ssn',
   data: '012-34-5678',
   nonce: '328493defaf6-576a-f9b4-169e-f5cc6b75'
+ },
+ {
+  type: 'attestation-types',
+  data: 'phone, ssn',
+  nonce: '328493defaf6-576a-f9b4-169e-f5cc6b75'
  }
 ]
 ```
-Each component of the data is hashed individually, then the resulting array is hashed into the dataHash.
-```
-// Step 1
-componentHashes = [hash1, hash2, ...]
-// Step 2
-dataHash = hash(componentHashes)
-```
-If a 3rd party requests a Bloom user to reveal the data that was submitted as part of an attestation, the user can choose to reveal none, some or all of the data by sending the 3rd party the hashed or plaintext data.
+Each component of the data is used to build a merkle tree. The root hash of the tree is the dataHash
 
-### TypeIds
-Attestations reference an array of typeIds. typeIds refers to the index of an enabled attestation type in the *Attestation Logic*. Bloom adds attestation types to this array as they are enabled in the protocol. The current identity types that can be attested are:
-0 => ‘phone’ => Associate a phone number with a BloomId
-1 => ‘email’ => Associate an email address with a BloomId
-```
-string[] public permittedTypesList;
-```
-The typeIds need to be included in the signatures for the attestation process. When being signed, the typeIds are hashed into a typeHash.
-```
-typeHash = soliditySha3({ type: "uint256[]", value: typeIds }) }
-```
+If a 3rd party requests a Bloom user to reveal the data that was submitted as part of an attestation, the user can choose to reveal none, some or all of the data by sending the 3rd party the merkle proof and selected plaintext data.
+
 ### RequesterId, AttesterId & SubjectId
 The entity requesting the attestation may be different from the user who is the subject of the attestation. Some 3rd party may be interested in a user having their name, phone number and address verified prior to offering them some service.
 
@@ -722,7 +692,6 @@ A simplified view of the attestation process is:
    * @param _paymentNonce Nonce referenced in TokenEscrowMarketplace so payment sig can't be replayed
    * @param _requesterSig Signature authorizing payment from requester to attester
    * @param _dataHash Hash of data being attested and nonce
-   * @param _typeIds Array of trait type ids to validate
    * @param _requestNonce Nonce in sig signed by subject so it can't be replayed
    * @param _subjectSig Signed authorization from subject with attestation agreement
    */
@@ -733,7 +702,6 @@ A simplified view of the attestation process is:
     bytes32 _paymentNonce,
     bytes _requesterSig,
     bytes32 _dataHash,
-    uint256[] _typeIds,
     bytes32 _requestNonce,
     bytes _subjectSig,
   ) public
@@ -747,7 +715,6 @@ A simplified view of the attestation process is:
     attesterAddress,
     requesterAddress,
     combinedDataHash,
-    [0, 1], // type Ids corresponding to phone and email
     requestNonce,
     subjectPrivKey
   )
@@ -766,7 +733,6 @@ A simplified view of the attestation process is:
     paymentNonce,
     tokenReleaseSig,
     combinedDataHash,
-    [0, 1],
     requestNonce,
     signedAttestationAgreement,
     {from: attesterAddress}
@@ -829,7 +795,6 @@ The attester calls contest to redeem payment for a failed attestation without le
     attesterAddress,
     requesterAddress,
     combinedDataHash,
-    [0, 1], // type Ids corresponding to phone and email
     requestNonce,
     subjectPrivKey
   )
@@ -862,7 +827,6 @@ A user can submit a staked attestation in which they lock up BLT for a specified
    * @param _paymentNonce Nonce in PaymentSig to add randomness to payment authorization
    * @param _paymentSig Signature from staker authorizing tokens to be released to collateral contract
    * @param _dataHash Hash of data being attested and nonce
-   * @param _typeIds Array of trait type ids being attested
    * param _requestNonce Nonce in sig signed by subject so it can't be replayed
    * @param _subjectSig Signed authorization from subject with attestation agreement
    * @param _stakeDuration Time until stake will be complete, max 1 year
@@ -873,7 +837,6 @@ A user can submit a staked attestation in which they lock up BLT for a specified
     bytes32 _paymentNonce,
     bytes _paymentSig,
     bytes32 _dataHash,
-    uint256[] _typeIds,
     bytes32 _requestNonce,
     bytes _subjectSig,
     uint256 _stakeDuration
@@ -888,7 +851,6 @@ A user can submit a staked attestation in which they lock up BLT for a specified
     stakerAddress,
     stakerAddress,
     combinedDataHash,
-    [3], // type Id corresponding to 'creditworthy'
     requestNonce,
     subjectPrivKey
   )
@@ -909,7 +871,6 @@ A user can submit a staked attestation in which they lock up BLT for a specified
     paymentNonce,
     tokenReleaseSig,
     combinedDataHash,
-    [3],
     requestNonce,
     signedAttestationAgreement,
     stakeDuration,
@@ -940,7 +901,6 @@ After a staking period has ended, a user can reclaim their tokens by calling rec
     stakerAddress,
     stakerAddress,
     combinedDataHash,
-    [3], // type Id corresponding to 'creditworthy'
     requestNonce,
     subjectPrivKey
   )
@@ -961,7 +921,6 @@ After a staking period has ended, a user can reclaim their tokens by calling rec
     paymentNonce,
     tokenReleaseSig,
     combinedDataHash,
-    [3],
     requestNonce,
     signedAttestationAgreement,
     stakeDuration,
@@ -996,7 +955,6 @@ During a staking period, a staker can revoke their stake and reclaim all of thei
     stakerAddress,
     stakerAddress,
     combinedDataHash,
-    [3], // type Id corresponding to 'creditworthy'
     requestNonce,
     subjectPrivKey
   )
@@ -1031,20 +989,6 @@ During a staking period, a staker can revoke their stake and reclaim all of thei
 
 ## Attestation Logic Admin Functions
 Bloom has administrative privileges to submit delegated transactions for user and configure the external contracts. 
-### createType
-Bloom maintains a list of permitted data types that can be associated with a user's BloomID.
-#### Interface
-```
-  function createType(string _traitType) public onlyOwner;
-```
-#### Data Structure
-```
-// Public list so others can check which types are supported
-  string[] public permittedTypesList;
-// mapping for checking if a type is valid
-// private because can't have getter for dynamically sized key
-  mapping(string => bool) private permittedTypesMapping;
-```
 
 ### attestFor
 Users can delegate certain protocol actions to the Bloom admin in order to have Bloom pays the transaction costs, as described in *Signing Logic*. An attester can collect all the signatures and data necessary for an attestation, sign them, then send the transaction information to Bloom to submit to the contract.
@@ -1061,7 +1005,6 @@ The nonces are included in the signature to make these signatures single-use. Th
     bytes32 _paymentNonce,
     bytes _requesterSig,
     bytes32 _dataHash,
-    uint256[] _typeIds,
     bytes32 _requestNonce,
     bytes _subjectSig,
     bytes _delegationSig
@@ -1070,7 +1013,7 @@ The nonces are included in the signature to make these signatures single-use. Th
 #### Signing Logic
 ```
   bytes32 constant ATTEST_FOR_TYPEHASH = keccak256(
-    "AttestFor(address subject,address requester,uint256 reward,bytes32 paymentNonce,bytes32 dataHash,bytes32 typeHash,bytes32 requestNonce)"
+    "AttestFor(address subject,address requester,uint256 reward,bytes32 paymentNonce,bytes32 dataHash,bytes32 requestNonce)"
   );
   struct AttestFor {
       address subject;
@@ -1078,7 +1021,6 @@ The nonces are included in the signature to make these signatures single-use. Th
       uint256 reward;
       bytes32 paymentNonce;
       bytes32 dataHash;
-      bytes32 typeHash;
       bytes32 requestNonce;
   }
 
@@ -1090,7 +1032,6 @@ The nonces are included in the signature to make these signatures single-use. Th
       request.reward,
       request.paymentNonce,
       request.dataHash,
-      request.typeHash,
       request.requestNonce
     ));
   }
@@ -1100,7 +1041,6 @@ The nonces are included in the signature to make these signatures single-use. Th
     uint256 _reward,
     bytes32 _paymentNonce,
     bytes32 _dataHash,
-    uint256[] _typeIds,
     bytes32 _requestNonce
   ) external view returns (bytes32) {
     return keccak256(
@@ -1113,7 +1053,6 @@ The nonces are included in the signature to make these signatures single-use. Th
           _reward,
           _paymentNonce,
           _dataHash,
-          keccak256(abi.encodePacked(_typeIds)),
           _requestNonce
         ))
       )
@@ -1181,7 +1120,6 @@ The nonces are included in the signature to make these signatures single-use. Th
     bytes32 _paymentNonce,
     bytes _paymentSig,
     bytes32 _dataHash,
-    uint256[] _typeIds,
     bytes32 _requestNonce,
     bytes _subjectSig,
     uint256 _stakeDuration,
@@ -1191,14 +1129,13 @@ The nonces are included in the signature to make these signatures single-use. Th
 #### Signing Logic
 ```
   bytes32 constant STAKE_FOR_TYPEHASH = keccak256(
-    "StakeFor(address subject,uint256 value,bytes32 paymentNonce,bytes32 dataHash,bytes32 typeHash,bytes32 requestNonce,uint256 stakeDuration)"
+    "StakeFor(address subject,uint256 value,bytes32 paymentNonce,bytes32 dataHash,bytes32 requestNonce,uint256 stakeDuration)"
   );
   struct StakeFor {
       address subject;
       uint256 value;
       bytes32 paymentNonce;
       bytes32 dataHash;
-      bytes32 typeHash;
       bytes32 requestNonce;
       uint256 stakeDuration;
   }
@@ -1210,7 +1147,6 @@ The nonces are included in the signature to make these signatures single-use. Th
       request.value,
       request.paymentNonce,
       request.dataHash,
-      request.typeHash,
       request.requestNonce,
       request.stakeDuration
     ));
@@ -1220,7 +1156,6 @@ The nonces are included in the signature to make these signatures single-use. Th
     uint256 _value,
     bytes32 _paymentNonce,
     bytes32 _dataHash,
-    uint256[] _typeIds,
     bytes32 _requestNonce,
     uint256 _stakeDuration
   ) external view returns (bytes32) {
@@ -1233,7 +1168,6 @@ The nonces are included in the signature to make these signatures single-use. Th
           _value,
           _paymentNonce,
           _dataHash,
-          keccak256(abi.encodePacked(_typeIds)),
           _requestNonce,
           _stakeDuration
         ))
@@ -1301,13 +1235,11 @@ Bloom can configure the external contracts associated with *Attestation Logic* i
     uint256 attesterId,
     uint256 requesterId,
     bytes32 dataHash,
-    uint256[] typeIds,
     uint256 stakeValue,
     uint256 expiresAt
     );
   event AttestationRejected(uint256 indexed attesterId, uint256 indexed requesterId);
   event AttestationRevoked(uint256 indexed subjectId, uint256 attestationId, uint256 indexed revokerId);
-  event TypeCreated(string traitType);
   event StakeSubmitted(uint256 indexed subjectId, uint256 indexed stakerId, uint256 attestationId, uint256 expiresAt);
   event StakedTokensReclaimed(uint256 indexed stakerId, uint256 value);
   event AccountRegistryChanged(address oldRegistry, address newRegistry);

--- a/contracts.d.ts
+++ b/contracts.d.ts
@@ -576,12 +576,6 @@ export interface AttestationLogicInstance extends ContractInstance {
     sendTransaction(options?: TransactionOptions): Promise<string>
     estimateGas(options?: TransactionOptions): Promise<number>
   }
-  permittedTypesList: {
-    (unnamed4: UInt, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
-    call(unnamed4: UInt, options?: TransactionOptions): Promise<string>
-    sendTransaction(unnamed4: UInt, options?: TransactionOptions): Promise<string>
-    estimateGas(unnamed4: UInt, options?: TransactionOptions): Promise<number>
-  }
   registry: {
     (options?: TransactionOptions): Promise<Web3.TransactionReceipt>
     call(options?: TransactionOptions): Promise<Address>
@@ -607,10 +601,10 @@ export interface AttestationLogicInstance extends ContractInstance {
     estimateGas(options?: TransactionOptions): Promise<number>
   }
   usedSignatures: {
-    (unnamed5: string, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
-    call(unnamed5: string, options?: TransactionOptions): Promise<boolean>
-    sendTransaction(unnamed5: string, options?: TransactionOptions): Promise<string>
-    estimateGas(unnamed5: string, options?: TransactionOptions): Promise<number>
+    (unnamed4: string, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(unnamed4: string, options?: TransactionOptions): Promise<boolean>
+    sendTransaction(unnamed4: string, options?: TransactionOptions): Promise<string>
+    estimateGas(unnamed4: string, options?: TransactionOptions): Promise<number>
   }
 
   TraitAttested: Web3.EventFilterCreator<{
@@ -619,7 +613,6 @@ export interface AttestationLogicInstance extends ContractInstance {
     attesterId: UInt
     requesterId: UInt
     dataHash: string
-    typeIds: UInt[]
     stakeValue: UInt
     expiresAt: UInt
   }>
@@ -627,8 +620,6 @@ export interface AttestationLogicInstance extends ContractInstance {
   AttestationRejected: Web3.EventFilterCreator<{ attesterId: UInt; requesterId: UInt }>
 
   AttestationRevoked: Web3.EventFilterCreator<{ subjectId: UInt; attestationId: UInt; revokerId: UInt }>
-
-  TypeCreated: Web3.EventFilterCreator<{ traitType: string }>
 
   StakeSubmitted: Web3.EventFilterCreator<{ subjectId: UInt; stakerId: UInt; attestationId: UInt; expiresAt: UInt }>
 
@@ -654,7 +645,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       paymentNonce: string,
       requesterSig: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       options?: TransactionOptions
@@ -666,7 +656,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       paymentNonce: string,
       requesterSig: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       options?: TransactionOptions
@@ -678,7 +667,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       paymentNonce: string,
       requesterSig: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       options?: TransactionOptions
@@ -690,7 +678,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       paymentNonce: string,
       requesterSig: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       options?: TransactionOptions
@@ -705,7 +692,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       paymentNonce: string,
       requesterSig: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       delegationSig: string,
@@ -719,7 +705,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       paymentNonce: string,
       requesterSig: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       delegationSig: string,
@@ -733,7 +718,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       paymentNonce: string,
       requesterSig: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       delegationSig: string,
@@ -747,7 +731,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       paymentNonce: string,
       requesterSig: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       delegationSig: string,
@@ -804,7 +787,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       attester: Address,
       requester: Address,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       options?: TransactionOptions
@@ -814,7 +796,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       attester: Address,
       requester: Address,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       options?: TransactionOptions
@@ -824,7 +805,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       attester: Address,
       requester: Address,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       options?: TransactionOptions
@@ -834,23 +814,10 @@ export interface AttestationLogicInstance extends ContractInstance {
       attester: Address,
       requester: Address,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       options?: TransactionOptions
     ): Promise<number>
-  }
-  createType: {
-    (traitType: string, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
-    call(traitType: string, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
-    sendTransaction(traitType: string, options?: TransactionOptions): Promise<string>
-    estimateGas(traitType: string, options?: TransactionOptions): Promise<number>
-  }
-  traitTypesExist: {
-    (typeIds: UInt[], options?: TransactionOptions): Promise<Web3.TransactionReceipt>
-    call(typeIds: UInt[], options?: TransactionOptions): Promise<boolean>
-    sendTransaction(typeIds: UInt[], options?: TransactionOptions): Promise<string>
-    estimateGas(typeIds: UInt[], options?: TransactionOptions): Promise<number>
   }
   revokeAttestation: {
     (subjectId: UInt, attestationId: UInt, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
@@ -865,7 +832,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       paymentNonce: string,
       paymentSig: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       stakeDuration: UInt,
@@ -877,7 +843,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       paymentNonce: string,
       paymentSig: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       stakeDuration: UInt,
@@ -889,7 +854,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       paymentNonce: string,
       paymentSig: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       stakeDuration: UInt,
@@ -901,7 +865,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       paymentNonce: string,
       paymentSig: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       stakeDuration: UInt,
@@ -916,7 +879,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       paymentNonce: string,
       paymentSig: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       stakeDuration: UInt,
@@ -930,7 +892,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       paymentNonce: string,
       paymentSig: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       stakeDuration: UInt,
@@ -944,7 +905,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       paymentNonce: string,
       paymentSig: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       stakeDuration: UInt,
@@ -958,7 +918,6 @@ export interface AttestationLogicInstance extends ContractInstance {
       paymentNonce: string,
       paymentSig: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       subjectSig: string,
       stakeDuration: UInt,
@@ -1066,7 +1025,6 @@ export interface AttestationLogicUpgradeModeInstance extends ContractInstance {
     attesterId: UInt
     requesterId: UInt
     dataHash: string
-    typeIds: UInt[]
     stakeValue: UInt
     expiresAt: UInt
   }>
@@ -1074,21 +1032,14 @@ export interface AttestationLogicUpgradeModeInstance extends ContractInstance {
   OwnershipTransferred: Web3.EventFilterCreator<{ previousOwner: Address; newOwner: Address }>
 
   proxyWriteAttestation: {
-    (
-      subject: Address,
-      attester: Address,
-      requester: Address,
-      dataHash: string,
-      typeIds: UInt[],
-      timestamp: UInt,
-      options?: TransactionOptions
-    ): Promise<Web3.TransactionReceipt>
+    (subject: Address, attester: Address, requester: Address, dataHash: string, timestamp: UInt, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >
     call(
       subject: Address,
       attester: Address,
       requester: Address,
       dataHash: string,
-      typeIds: UInt[],
       timestamp: UInt,
       options?: TransactionOptions
     ): Promise<Web3.TransactionReceipt>
@@ -1097,7 +1048,6 @@ export interface AttestationLogicUpgradeModeInstance extends ContractInstance {
       attester: Address,
       requester: Address,
       dataHash: string,
-      typeIds: UInt[],
       timestamp: UInt,
       options?: TransactionOptions
     ): Promise<string>
@@ -1106,7 +1056,6 @@ export interface AttestationLogicUpgradeModeInstance extends ContractInstance {
       attester: Address,
       requester: Address,
       dataHash: string,
-      typeIds: UInt[],
       timestamp: UInt,
       options?: TransactionOptions
     ): Promise<number>
@@ -1151,14 +1100,14 @@ export interface AttestationRepoInstance extends ContractInstance {
     estimateGas(options?: TransactionOptions): Promise<number>
   }
   attestations: {
-    (unnamed6: UInt, unnamed7: UInt, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    (unnamed5: UInt, unnamed6: UInt, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
     call(
+      unnamed5: UInt,
       unnamed6: UInt,
-      unnamed7: UInt,
       options?: TransactionOptions
     ): Promise<[BigNumber.BigNumber, BigNumber.BigNumber, BigNumber.BigNumber, BigNumber.BigNumber]>
-    sendTransaction(unnamed6: UInt, unnamed7: UInt, options?: TransactionOptions): Promise<string>
-    estimateGas(unnamed6: UInt, unnamed7: UInt, options?: TransactionOptions): Promise<number>
+    sendTransaction(unnamed5: UInt, unnamed6: UInt, options?: TransactionOptions): Promise<string>
+    estimateGas(unnamed5: UInt, unnamed6: UInt, options?: TransactionOptions): Promise<number>
   }
   transferOwnership: {
     (newOwner: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
@@ -1377,10 +1326,10 @@ export interface BLTInstance extends ContractInstance {
     estimateGas(options?: TransactionOptions): Promise<number>
   }
   canCreateGrants: {
-    (unnamed8: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
-    call(unnamed8: Address, options?: TransactionOptions): Promise<boolean>
-    sendTransaction(unnamed8: Address, options?: TransactionOptions): Promise<string>
-    estimateGas(unnamed8: Address, options?: TransactionOptions): Promise<number>
+    (unnamed7: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(unnamed7: Address, options?: TransactionOptions): Promise<boolean>
+    sendTransaction(unnamed7: Address, options?: TransactionOptions): Promise<string>
+    estimateGas(unnamed7: Address, options?: TransactionOptions): Promise<number>
   }
   setCanCreateGrants: {
     (addr: Address, allowed: boolean, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
@@ -1395,14 +1344,14 @@ export interface BLTInstance extends ContractInstance {
     estimateGas(from: Address, to: Address, value: UInt, options?: TransactionOptions): Promise<number>
   }
   grants: {
-    (unnamed9: Address, unnamed10: UInt, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    (unnamed8: Address, unnamed9: UInt, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
     call(
-      unnamed9: Address,
-      unnamed10: UInt,
+      unnamed8: Address,
+      unnamed9: UInt,
       options?: TransactionOptions
     ): Promise<[Address, BigNumber.BigNumber, BigNumber.BigNumber, BigNumber.BigNumber, BigNumber.BigNumber, boolean, boolean]>
-    sendTransaction(unnamed9: Address, unnamed10: UInt, options?: TransactionOptions): Promise<string>
-    estimateGas(unnamed9: Address, unnamed10: UInt, options?: TransactionOptions): Promise<number>
+    sendTransaction(unnamed8: Address, unnamed9: UInt, options?: TransactionOptions): Promise<string>
+    estimateGas(unnamed8: Address, unnamed9: UInt, options?: TransactionOptions): Promise<number>
   }
   decimals: {
     (options?: TransactionOptions): Promise<Web3.TransactionReceipt>
@@ -2169,20 +2118,20 @@ export interface MiniMeVestedTokenInstance extends ContractInstance {
     estimateGas(options?: TransactionOptions): Promise<number>
   }
   canCreateGrants: {
-    (unnamed11: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
-    call(unnamed11: Address, options?: TransactionOptions): Promise<boolean>
-    sendTransaction(unnamed11: Address, options?: TransactionOptions): Promise<string>
-    estimateGas(unnamed11: Address, options?: TransactionOptions): Promise<number>
+    (unnamed10: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(unnamed10: Address, options?: TransactionOptions): Promise<boolean>
+    sendTransaction(unnamed10: Address, options?: TransactionOptions): Promise<string>
+    estimateGas(unnamed10: Address, options?: TransactionOptions): Promise<number>
   }
   grants: {
-    (unnamed12: Address, unnamed13: UInt, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    (unnamed11: Address, unnamed12: UInt, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
     call(
-      unnamed12: Address,
-      unnamed13: UInt,
+      unnamed11: Address,
+      unnamed12: UInt,
       options?: TransactionOptions
     ): Promise<[Address, BigNumber.BigNumber, BigNumber.BigNumber, BigNumber.BigNumber, BigNumber.BigNumber, boolean, boolean]>
-    sendTransaction(unnamed12: Address, unnamed13: UInt, options?: TransactionOptions): Promise<string>
-    estimateGas(unnamed12: Address, unnamed13: UInt, options?: TransactionOptions): Promise<number>
+    sendTransaction(unnamed11: Address, unnamed12: UInt, options?: TransactionOptions): Promise<string>
+    estimateGas(unnamed11: Address, unnamed12: UInt, options?: TransactionOptions): Promise<number>
   }
   decimals: {
     (options?: TransactionOptions): Promise<Web3.TransactionReceipt>
@@ -2619,10 +2568,10 @@ export interface PollInstance extends ContractInstance {
     estimateGas(options?: TransactionOptions): Promise<number>
   }
   votes: {
-    (unnamed14: UInt, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
-    call(unnamed14: UInt, options?: TransactionOptions): Promise<BigNumber.BigNumber>
-    sendTransaction(unnamed14: UInt, options?: TransactionOptions): Promise<string>
-    estimateGas(unnamed14: UInt, options?: TransactionOptions): Promise<number>
+    (unnamed13: UInt, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(unnamed13: UInt, options?: TransactionOptions): Promise<BigNumber.BigNumber>
+    sendTransaction(unnamed13: UInt, options?: TransactionOptions): Promise<string>
+    estimateGas(unnamed13: UInt, options?: TransactionOptions): Promise<number>
   }
   startTime: {
     (options?: TransactionOptions): Promise<Web3.TransactionReceipt>
@@ -2661,10 +2610,10 @@ export interface PollInstance extends ContractInstance {
     estimateGas(options?: TransactionOptions): Promise<number>
   }
   usedSignatures: {
-    (unnamed15: string, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
-    call(unnamed15: string, options?: TransactionOptions): Promise<boolean>
-    sendTransaction(unnamed15: string, options?: TransactionOptions): Promise<string>
-    estimateGas(unnamed15: string, options?: TransactionOptions): Promise<number>
+    (unnamed14: string, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(unnamed14: string, options?: TransactionOptions): Promise<boolean>
+    sendTransaction(unnamed14: string, options?: TransactionOptions): Promise<string>
+    estimateGas(unnamed14: string, options?: TransactionOptions): Promise<number>
   }
 
   VoteCast: Web3.EventFilterCreator<{ voter: Address; choice: UInt }>
@@ -2717,30 +2666,15 @@ export interface SafeMathContract {
 
 export interface SigningLogicInstance extends ContractInstance {
   generateRequestAttestationSchemaHash: {
-    (
-      subject: Address,
-      attester: Address,
-      requester: Address,
-      dataHash: string,
-      typeIds: UInt[],
-      nonce: string,
-      options?: TransactionOptions
-    ): Promise<Web3.TransactionReceipt>
-    call(
-      subject: Address,
-      attester: Address,
-      requester: Address,
-      dataHash: string,
-      typeIds: UInt[],
-      nonce: string,
-      options?: TransactionOptions
-    ): Promise<string>
+    (subject: Address, attester: Address, requester: Address, dataHash: string, nonce: string, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >
+    call(subject: Address, attester: Address, requester: Address, dataHash: string, nonce: string, options?: TransactionOptions): Promise<string>
     sendTransaction(
       subject: Address,
       attester: Address,
       requester: Address,
       dataHash: string,
-      typeIds: UInt[],
       nonce: string,
       options?: TransactionOptions
     ): Promise<string>
@@ -2749,7 +2683,6 @@ export interface SigningLogicInstance extends ContractInstance {
       attester: Address,
       requester: Address,
       dataHash: string,
-      typeIds: UInt[],
       nonce: string,
       options?: TransactionOptions
     ): Promise<number>
@@ -2773,7 +2706,6 @@ export interface SigningLogicInstance extends ContractInstance {
       reward: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       options?: TransactionOptions
     ): Promise<Web3.TransactionReceipt>
@@ -2783,7 +2715,6 @@ export interface SigningLogicInstance extends ContractInstance {
       reward: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       options?: TransactionOptions
     ): Promise<string>
@@ -2793,7 +2724,6 @@ export interface SigningLogicInstance extends ContractInstance {
       reward: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       options?: TransactionOptions
     ): Promise<string>
@@ -2803,7 +2733,6 @@ export interface SigningLogicInstance extends ContractInstance {
       reward: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       options?: TransactionOptions
     ): Promise<number>
@@ -2820,7 +2749,6 @@ export interface SigningLogicInstance extends ContractInstance {
       value: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       stakeDuration: UInt,
       options?: TransactionOptions
@@ -2830,7 +2758,6 @@ export interface SigningLogicInstance extends ContractInstance {
       value: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       stakeDuration: UInt,
       options?: TransactionOptions
@@ -2840,7 +2767,6 @@ export interface SigningLogicInstance extends ContractInstance {
       value: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       stakeDuration: UInt,
       options?: TransactionOptions
@@ -2850,7 +2776,6 @@ export interface SigningLogicInstance extends ContractInstance {
       value: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       stakeDuration: UInt,
       options?: TransactionOptions
@@ -2896,30 +2821,15 @@ export interface SigningLogicInterfaceInstance extends ContractInstance {
     estimateGas(hash: string, sig: string, options?: TransactionOptions): Promise<number>
   }
   generateRequestAttestationSchemaHash: {
-    (
-      subject: Address,
-      attester: Address,
-      requester: Address,
-      dataHash: string,
-      typeIds: UInt[],
-      nonce: string,
-      options?: TransactionOptions
-    ): Promise<Web3.TransactionReceipt>
-    call(
-      subject: Address,
-      attester: Address,
-      requester: Address,
-      dataHash: string,
-      typeIds: UInt[],
-      nonce: string,
-      options?: TransactionOptions
-    ): Promise<string>
+    (subject: Address, attester: Address, requester: Address, dataHash: string, nonce: string, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >
+    call(subject: Address, attester: Address, requester: Address, dataHash: string, nonce: string, options?: TransactionOptions): Promise<string>
     sendTransaction(
       subject: Address,
       attester: Address,
       requester: Address,
       dataHash: string,
-      typeIds: UInt[],
       nonce: string,
       options?: TransactionOptions
     ): Promise<string>
@@ -2928,7 +2838,6 @@ export interface SigningLogicInterfaceInstance extends ContractInstance {
       attester: Address,
       requester: Address,
       dataHash: string,
-      typeIds: UInt[],
       nonce: string,
       options?: TransactionOptions
     ): Promise<number>
@@ -2940,7 +2849,6 @@ export interface SigningLogicInterfaceInstance extends ContractInstance {
       reward: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       options?: TransactionOptions
     ): Promise<Web3.TransactionReceipt>
@@ -2950,7 +2858,6 @@ export interface SigningLogicInterfaceInstance extends ContractInstance {
       reward: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       options?: TransactionOptions
     ): Promise<string>
@@ -2960,7 +2867,6 @@ export interface SigningLogicInterfaceInstance extends ContractInstance {
       reward: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       options?: TransactionOptions
     ): Promise<string>
@@ -2970,7 +2876,6 @@ export interface SigningLogicInterfaceInstance extends ContractInstance {
       reward: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       options?: TransactionOptions
     ): Promise<number>
@@ -2987,7 +2892,6 @@ export interface SigningLogicInterfaceInstance extends ContractInstance {
       value: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       stakeDuration: UInt,
       options?: TransactionOptions
@@ -2997,7 +2901,6 @@ export interface SigningLogicInterfaceInstance extends ContractInstance {
       value: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       stakeDuration: UInt,
       options?: TransactionOptions
@@ -3007,7 +2910,6 @@ export interface SigningLogicInterfaceInstance extends ContractInstance {
       value: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       stakeDuration: UInt,
       options?: TransactionOptions
@@ -3017,7 +2919,6 @@ export interface SigningLogicInterfaceInstance extends ContractInstance {
       value: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       stakeDuration: UInt,
       options?: TransactionOptions
@@ -3063,30 +2964,15 @@ export interface SigningLogicInterfaceContract {
 
 export interface SigningLogicLegacyInstance extends ContractInstance {
   generateRequestAttestationSchemaHash: {
-    (
-      subject: Address,
-      attester: Address,
-      requester: Address,
-      dataHash: string,
-      typeIds: UInt[],
-      nonce: string,
-      options?: TransactionOptions
-    ): Promise<Web3.TransactionReceipt>
-    call(
-      subject: Address,
-      attester: Address,
-      requester: Address,
-      dataHash: string,
-      typeIds: UInt[],
-      nonce: string,
-      options?: TransactionOptions
-    ): Promise<string>
+    (subject: Address, attester: Address, requester: Address, dataHash: string, nonce: string, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >
+    call(subject: Address, attester: Address, requester: Address, dataHash: string, nonce: string, options?: TransactionOptions): Promise<string>
     sendTransaction(
       subject: Address,
       attester: Address,
       requester: Address,
       dataHash: string,
-      typeIds: UInt[],
       nonce: string,
       options?: TransactionOptions
     ): Promise<string>
@@ -3095,7 +2981,6 @@ export interface SigningLogicLegacyInstance extends ContractInstance {
       attester: Address,
       requester: Address,
       dataHash: string,
-      typeIds: UInt[],
       nonce: string,
       options?: TransactionOptions
     ): Promise<number>
@@ -3119,7 +3004,6 @@ export interface SigningLogicLegacyInstance extends ContractInstance {
       reward: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       options?: TransactionOptions
     ): Promise<Web3.TransactionReceipt>
@@ -3129,7 +3013,6 @@ export interface SigningLogicLegacyInstance extends ContractInstance {
       reward: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       options?: TransactionOptions
     ): Promise<string>
@@ -3139,7 +3022,6 @@ export interface SigningLogicLegacyInstance extends ContractInstance {
       reward: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       options?: TransactionOptions
     ): Promise<string>
@@ -3149,7 +3031,6 @@ export interface SigningLogicLegacyInstance extends ContractInstance {
       reward: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       options?: TransactionOptions
     ): Promise<number>
@@ -3166,7 +3047,6 @@ export interface SigningLogicLegacyInstance extends ContractInstance {
       value: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       stakeDuration: UInt,
       options?: TransactionOptions
@@ -3176,7 +3056,6 @@ export interface SigningLogicLegacyInstance extends ContractInstance {
       value: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       stakeDuration: UInt,
       options?: TransactionOptions
@@ -3186,7 +3065,6 @@ export interface SigningLogicLegacyInstance extends ContractInstance {
       value: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       stakeDuration: UInt,
       options?: TransactionOptions
@@ -3196,7 +3074,6 @@ export interface SigningLogicLegacyInstance extends ContractInstance {
       value: UInt,
       paymentNonce: string,
       dataHash: string,
-      typeIds: UInt[],
       requestNonce: string,
       stakeDuration: UInt,
       options?: TransactionOptions
@@ -3378,16 +3255,16 @@ export interface TokenEscrowMarketplaceInstance extends ContractInstance {
     estimateGas(newOwner: Address, options?: TransactionOptions): Promise<number>
   }
   tokenEscrow: {
-    (unnamed16: UInt, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
-    call(unnamed16: UInt, options?: TransactionOptions): Promise<BigNumber.BigNumber>
-    sendTransaction(unnamed16: UInt, options?: TransactionOptions): Promise<string>
-    estimateGas(unnamed16: UInt, options?: TransactionOptions): Promise<number>
+    (unnamed15: UInt, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(unnamed15: UInt, options?: TransactionOptions): Promise<BigNumber.BigNumber>
+    sendTransaction(unnamed15: UInt, options?: TransactionOptions): Promise<string>
+    estimateGas(unnamed15: UInt, options?: TransactionOptions): Promise<number>
   }
   usedSignatures: {
-    (unnamed17: string, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
-    call(unnamed17: string, options?: TransactionOptions): Promise<boolean>
-    sendTransaction(unnamed17: string, options?: TransactionOptions): Promise<string>
-    estimateGas(unnamed17: string, options?: TransactionOptions): Promise<number>
+    (unnamed16: string, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(unnamed16: string, options?: TransactionOptions): Promise<boolean>
+    sendTransaction(unnamed16: string, options?: TransactionOptions): Promise<string>
+    estimateGas(unnamed16: string, options?: TransactionOptions): Promise<number>
   }
   token: {
     (options?: TransactionOptions): Promise<Web3.TransactionReceipt>
@@ -3495,10 +3372,10 @@ export interface TokenEscrowMarketplaceContract {
 
 export interface VotingCenterInstance extends ContractInstance {
   polls: {
-    (unnamed18: UInt, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
-    call(unnamed18: UInt, options?: TransactionOptions): Promise<Address>
-    sendTransaction(unnamed18: UInt, options?: TransactionOptions): Promise<string>
-    estimateGas(unnamed18: UInt, options?: TransactionOptions): Promise<number>
+    (unnamed17: UInt, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(unnamed17: UInt, options?: TransactionOptions): Promise<Address>
+    sendTransaction(unnamed17: UInt, options?: TransactionOptions): Promise<string>
+    estimateGas(unnamed17: UInt, options?: TransactionOptions): Promise<number>
   }
   PollCreated: Web3.EventFilterCreator<{ poll: Address; author: Address }>
 

--- a/contracts/AttestationLogicUpgradeMode.sol
+++ b/contracts/AttestationLogicUpgradeMode.sol
@@ -39,7 +39,6 @@ contract AttestationLogicUpgradeMode is Ownable{
     uint256 attesterId,
     uint256 requesterId,
     bytes32 dataHash,
-    uint256[] typeIds,
     uint256 stakeValue,
     uint256 expiresAt
     );
@@ -51,7 +50,6 @@ contract AttestationLogicUpgradeMode is Ownable{
    * @param _attester User who is confirming subject's data
    * @param _requester User who is requesting the attestation be completed
    * @param _dataHash Hash of data and nonce for this attestation
-   * @param _typeIds array of trait type ids to validate
    * @param _timestamp Timestamp when this attestation was completed
    */
   function proxyWriteAttestation(
@@ -59,7 +57,6 @@ contract AttestationLogicUpgradeMode is Ownable{
     address _attester,
     address _requester,
     bytes32 _dataHash,
-    uint256[] _typeIds,
     uint256 _timestamp
   ) public onlyOwner {
     uint256 _requesterId = registry.accountIdForAddress(_requester);
@@ -80,7 +77,6 @@ contract AttestationLogicUpgradeMode is Ownable{
       _attesterId,
       _requesterId,
       _dataHash,
-      _typeIds,
       0,
       0
     );

--- a/contracts/SigningLogic.sol
+++ b/contracts/SigningLogic.sol
@@ -13,11 +13,11 @@ import "./SigningLogicInterface.sol";
 contract SigningLogic is SigningLogicInterface{
 
   bytes32 constant EIP712DOMAIN_TYPEHASH = keccak256(
-    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    "EIP712Domain(string name,string version)"
   );
 
   bytes32 constant ATTESTATION_REQUEST_TYPEHASH = keccak256(
-    "AttestationRequest(address subject,address attester,address requester,bytes32 dataHash,bytes32 typeHash,bytes32 nonce)"
+    "AttestationRequest(address subject,address attester,address requester,bytes32 dataHash,bytes32 nonce)"
   );
 
   bytes32 constant ADD_ADDRESS_TYPEHASH = keccak256(
@@ -29,7 +29,7 @@ contract SigningLogic is SigningLogicInterface{
   );
 
   bytes32 constant ATTEST_FOR_TYPEHASH = keccak256(
-    "AttestFor(address subject,address requester,uint256 reward,bytes32 paymentNonce,bytes32 dataHash,bytes32 typeHash,bytes32 requestNonce)"
+    "AttestFor(address subject,address requester,uint256 reward,bytes32 paymentNonce,bytes32 dataHash,bytes32 requestNonce)"
   );
 
   bytes32 constant CONTEST_FOR_TYPEHASH = keccak256(
@@ -37,7 +37,7 @@ contract SigningLogic is SigningLogicInterface{
   );
 
   bytes32 constant STAKE_FOR_TYPEHASH = keccak256(
-    "StakeFor(address subject,uint256 value,bytes32 paymentNonce,bytes32 dataHash,bytes32 typeHash,bytes32 requestNonce,uint256 stakeDuration)"
+    "StakeFor(address subject,uint256 value,bytes32 paymentNonce,bytes32 dataHash,bytes32 requestNonce,uint256 stakeDuration)"
   );
 
   bytes32 constant REVOKE_STAKE_FOR_TYPEHASH = keccak256(
@@ -57,27 +57,20 @@ contract SigningLogic is SigningLogicInterface{
   constructor () public {
     DOMAIN_SEPARATOR = hash(EIP712Domain({
       name: "Bloom",
-      version: '1',
-      chainId: 4,
-      // verifyingContract: this
-      verifyingContract: 0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC
+      version: '1'
     }));
   }
 
   struct EIP712Domain {
       string  name;
       string  version;
-      uint256 chainId;
-      address verifyingContract;
   }
 
   function hash(EIP712Domain eip712Domain) internal pure returns (bytes32) {
     return keccak256(abi.encode(
       EIP712DOMAIN_TYPEHASH,
       keccak256(bytes(eip712Domain.name)),
-      keccak256(bytes(eip712Domain.version)),
-      eip712Domain.chainId,
-      eip712Domain.verifyingContract
+      keccak256(bytes(eip712Domain.version))
     ));
   }
 
@@ -86,7 +79,6 @@ contract SigningLogic is SigningLogicInterface{
       address attester;
       address requester;
       bytes32 dataHash;
-      bytes32 typeHash;
       bytes32 nonce;
   }
 
@@ -97,7 +89,6 @@ contract SigningLogic is SigningLogicInterface{
       request.attester,
       request.requester,
       request.dataHash,
-      request.typeHash,
       request.nonce
     ));
   }
@@ -138,7 +129,6 @@ contract SigningLogic is SigningLogicInterface{
       uint256 reward;
       bytes32 paymentNonce;
       bytes32 dataHash;
-      bytes32 typeHash;
       bytes32 requestNonce;
   }
 
@@ -150,7 +140,6 @@ contract SigningLogic is SigningLogicInterface{
       request.reward,
       request.paymentNonce,
       request.dataHash,
-      request.typeHash,
       request.requestNonce
     ));
   }
@@ -175,7 +164,6 @@ contract SigningLogic is SigningLogicInterface{
       uint256 value;
       bytes32 paymentNonce;
       bytes32 dataHash;
-      bytes32 typeHash;
       bytes32 requestNonce;
       uint256 stakeDuration;
   }
@@ -187,7 +175,6 @@ contract SigningLogic is SigningLogicInterface{
       request.value,
       request.paymentNonce,
       request.dataHash,
-      request.typeHash,
       request.requestNonce,
       request.stakeDuration
     ));
@@ -243,7 +230,6 @@ contract SigningLogic is SigningLogicInterface{
     address _attester,
     address _requester,
     bytes32 _dataHash,
-    uint256[] _typeIds,
     bytes32 _nonce
   ) external view returns (bytes32) {
     return keccak256(
@@ -255,7 +241,6 @@ contract SigningLogic is SigningLogicInterface{
           _attester,
           _requester,
           _dataHash,
-          keccak256(abi.encodePacked(_typeIds)),
           _nonce
         ))
       )
@@ -304,7 +289,6 @@ contract SigningLogic is SigningLogicInterface{
     uint256 _reward,
     bytes32 _paymentNonce,
     bytes32 _dataHash,
-    uint256[] _typeIds,
     bytes32 _requestNonce
   ) external view returns (bytes32) {
     return keccak256(
@@ -317,7 +301,6 @@ contract SigningLogic is SigningLogicInterface{
           _reward,
           _paymentNonce,
           _dataHash,
-          keccak256(abi.encodePacked(_typeIds)),
           _requestNonce
         ))
       )
@@ -347,7 +330,6 @@ contract SigningLogic is SigningLogicInterface{
     uint256 _value,
     bytes32 _paymentNonce,
     bytes32 _dataHash,
-    uint256[] _typeIds,
     bytes32 _requestNonce,
     uint256 _stakeDuration
   ) external view returns (bytes32) {
@@ -360,7 +342,6 @@ contract SigningLogic is SigningLogicInterface{
           _value,
           _paymentNonce,
           _dataHash,
-          keccak256(abi.encodePacked(_typeIds)),
           _requestNonce,
           _stakeDuration
         ))

--- a/contracts/SigningLogicInterface.sol
+++ b/contracts/SigningLogicInterface.sol
@@ -7,7 +7,6 @@ contract SigningLogicInterface {
     address _attester,
     address _requester,
     bytes32 _dataHash,
-    uint256[] _typeIds,
     bytes32 _nonce
     ) external view returns (bytes32);
   function generateAttestForDelegationSchemaHash(
@@ -16,7 +15,6 @@ contract SigningLogicInterface {
     uint256 _reward,
     bytes32 _paymentNonce,
     bytes32 _dataHash,
-    uint256[] _typeIds,
     bytes32 _requestNonce
     ) external view returns (bytes32);
   function generateContestForDelegationSchemaHash(
@@ -29,7 +27,6 @@ contract SigningLogicInterface {
     uint256 _value,
     bytes32 _paymentNonce,
     bytes32 _dataHash,
-    uint256[] _typeIds,
     bytes32 _requestNonce,
     uint256 _stakeDuration
     ) external view returns (bytes32);

--- a/contracts/SigningLogicLegacy.sol
+++ b/contracts/SigningLogicLegacy.sol
@@ -18,7 +18,6 @@ contract SigningLogicLegacy is SigningLogicInterface{
         "address attester",
         "address requester",
         "bytes32 dataHash",
-        "bytes32 typeHash",
         "bytes32 nonce"
       )
   );
@@ -48,7 +47,6 @@ contract SigningLogicLegacy is SigningLogicInterface{
         "uint256 reward", 
         "bytes32 paymentNonce",
         "bytes32 dataHash",
-        "bytes32 typeHash",
         "bytes32 requestNonce"
       )
   );
@@ -69,7 +67,6 @@ contract SigningLogicLegacy is SigningLogicInterface{
         "uint256 value", 
         "bytes32 paymentNonce",
         "bytes32 dataHash",
-        "bytes32 typeHash",
         "bytes32 requestNonce",
         "uint256 stakeDuration"
       )
@@ -92,7 +89,7 @@ contract SigningLogicLegacy is SigningLogicInterface{
       )
   );
 
-  bytes32 constant LOCKUP_TOKENS_FOR = keccak256(
+  bytes32 constant LOCKUP_TOKENS_FOR_TYPEHASH = keccak256(
       abi.encodePacked(
         "string action",
         "address sender",
@@ -106,7 +103,6 @@ contract SigningLogicLegacy is SigningLogicInterface{
       address attester;
       address requester;
       bytes32 dataHash;
-      bytes32 typeHash;
       bytes32 nonce;
   }
 
@@ -120,7 +116,6 @@ contract SigningLogicLegacy is SigningLogicInterface{
             request.attester,
             request.requester,
             request.dataHash,
-            request.typeHash,
             request.nonce
           )
         )
@@ -174,7 +169,6 @@ contract SigningLogicLegacy is SigningLogicInterface{
       uint256 reward;
       bytes32 paymentNonce;
       bytes32 dataHash;
-      bytes32 typeHash;
       bytes32 requestNonce;
   }
 
@@ -190,7 +184,6 @@ contract SigningLogicLegacy is SigningLogicInterface{
             request.reward,
             request.paymentNonce,
             request.dataHash,
-            request.typeHash,
             request.requestNonce
           )
         )
@@ -223,7 +216,6 @@ contract SigningLogicLegacy is SigningLogicInterface{
       uint256 value;
       bytes32 paymentNonce;
       bytes32 dataHash;
-      bytes32 typeHash;
       bytes32 requestNonce;
       uint256 stakeDuration;
   }
@@ -239,7 +231,6 @@ contract SigningLogicLegacy is SigningLogicInterface{
             request.value,
             request.paymentNonce,
             request.dataHash,
-            request.typeHash,
             request.requestNonce,
             request.stakeDuration
           )
@@ -297,7 +288,7 @@ contract SigningLogicLegacy is SigningLogicInterface{
   function hash(LockupTokensFor request) internal pure returns (bytes32) {
     return keccak256(
       abi.encodePacked(
-        LOCKUP_TOKENS_FOR,
+        LOCKUP_TOKENS_FOR_TYPEHASH,
         keccak256(
           abi.encodePacked(
             "lockup",
@@ -314,7 +305,6 @@ contract SigningLogicLegacy is SigningLogicInterface{
     address _attester,
     address _requester,
     bytes32 _dataHash,
-    uint256[] _typeIds,
     bytes32 _nonce
   ) external view returns (bytes32) {
     return hash(
@@ -323,7 +313,6 @@ contract SigningLogicLegacy is SigningLogicInterface{
         _attester,
         _requester,
         _dataHash,
-        keccak256(abi.encodePacked(_typeIds)),
         _nonce
       )
     );
@@ -363,7 +352,6 @@ contract SigningLogicLegacy is SigningLogicInterface{
     uint256 _reward,
     bytes32 _paymentNonce,
     bytes32 _dataHash,
-    uint256[] _typeIds,
     bytes32 _requestNonce
   ) external view returns (bytes32) {
     return hash(
@@ -373,7 +361,6 @@ contract SigningLogicLegacy is SigningLogicInterface{
         _reward,
         _paymentNonce,
         _dataHash,
-        keccak256(abi.encodePacked(_typeIds)),
         _requestNonce
       )
     );
@@ -398,7 +385,6 @@ contract SigningLogicLegacy is SigningLogicInterface{
     uint256 _value,
     bytes32 _paymentNonce,
     bytes32 _dataHash,
-    uint256[] _typeIds,
     bytes32 _requestNonce,
     uint256 _stakeDuration
   ) external view returns (bytes32) {
@@ -408,7 +394,6 @@ contract SigningLogicLegacy is SigningLogicInterface{
         _value,
         _paymentNonce,
         _dataHash,
-        keccak256(abi.encodePacked(_typeIds)),
         _requestNonce,
         _stakeDuration
       )

--- a/method_manifest.ts
+++ b/method_manifest.ts
@@ -595,15 +595,6 @@ export const AttestationLogic: IContractMethodManifest = {
       args_arr: [],
       args: {}
     },
-    permittedTypesList: {
-      args_arr: ["anonymous_0"],
-      args: {
-        anonymous_0: {
-          type: "uint256",
-          index: 0
-        }
-      }
-    },
     registry: {
       args_arr: [],
       args: {}
@@ -636,7 +627,7 @@ export const AttestationLogic: IContractMethodManifest = {
     },
 
     attest: {
-      args_arr: ["_subject", "_requester", "_reward", "_paymentNonce", "_requesterSig", "_dataHash", "_typeIds", "_requestNonce", "_subjectSig"],
+      args_arr: ["_subject", "_requester", "_reward", "_paymentNonce", "_requesterSig", "_dataHash", "_requestNonce", "_subjectSig"],
       args: {
         _subject: {
           type: "address",
@@ -662,17 +653,13 @@ export const AttestationLogic: IContractMethodManifest = {
           type: "bytes32",
           index: 5
         },
-        _typeIds: {
-          type: "uint256[]",
-          index: 6
-        },
         _requestNonce: {
           type: "bytes32",
-          index: 7
+          index: 6
         },
         _subjectSig: {
           type: "bytes",
-          index: 8
+          index: 7
         }
       }
     },
@@ -685,7 +672,6 @@ export const AttestationLogic: IContractMethodManifest = {
         "_paymentNonce",
         "_requesterSig",
         "_dataHash",
-        "_typeIds",
         "_requestNonce",
         "_subjectSig",
         "_delegationSig"
@@ -719,21 +705,17 @@ export const AttestationLogic: IContractMethodManifest = {
           type: "bytes32",
           index: 6
         },
-        _typeIds: {
-          type: "uint256[]",
-          index: 7
-        },
         _requestNonce: {
           type: "bytes32",
-          index: 8
+          index: 7
         },
         _subjectSig: {
           type: "bytes",
-          index: 9
+          index: 8
         },
         _delegationSig: {
           type: "bytes",
-          index: 10
+          index: 9
         }
       }
     },
@@ -788,7 +770,7 @@ export const AttestationLogic: IContractMethodManifest = {
       }
     },
     validateSubjectSig: {
-      args_arr: ["_subject", "_attester", "_requester", "_dataHash", "_typeIds", "_requestNonce", "_subjectSig"],
+      args_arr: ["_subject", "_attester", "_requester", "_dataHash", "_requestNonce", "_subjectSig"],
       args: {
         _subject: {
           type: "address",
@@ -806,35 +788,13 @@ export const AttestationLogic: IContractMethodManifest = {
           type: "bytes32",
           index: 3
         },
-        _typeIds: {
-          type: "uint256[]",
-          index: 4
-        },
         _requestNonce: {
           type: "bytes32",
-          index: 5
+          index: 4
         },
         _subjectSig: {
           type: "bytes",
-          index: 6
-        }
-      }
-    },
-    createType: {
-      args_arr: ["_traitType"],
-      args: {
-        _traitType: {
-          type: "string",
-          index: 0
-        }
-      }
-    },
-    traitTypesExist: {
-      args_arr: ["_typeIds"],
-      args: {
-        _typeIds: {
-          type: "uint256[]",
-          index: 0
+          index: 5
         }
       }
     },
@@ -852,7 +812,7 @@ export const AttestationLogic: IContractMethodManifest = {
       }
     },
     stake: {
-      args_arr: ["_subject", "_value", "_paymentNonce", "_paymentSig", "_dataHash", "_typeIds", "_requestNonce", "_subjectSig", "_stakeDuration"],
+      args_arr: ["_subject", "_value", "_paymentNonce", "_paymentSig", "_dataHash", "_requestNonce", "_subjectSig", "_stakeDuration"],
       args: {
         _subject: {
           type: "address",
@@ -874,21 +834,17 @@ export const AttestationLogic: IContractMethodManifest = {
           type: "bytes32",
           index: 4
         },
-        _typeIds: {
-          type: "uint256[]",
-          index: 5
-        },
         _requestNonce: {
           type: "bytes32",
-          index: 6
+          index: 5
         },
         _subjectSig: {
           type: "bytes",
-          index: 7
+          index: 6
         },
         _stakeDuration: {
           type: "uint256",
-          index: 8
+          index: 7
         }
       }
     },
@@ -900,7 +856,6 @@ export const AttestationLogic: IContractMethodManifest = {
         "_paymentNonce",
         "_paymentSig",
         "_dataHash",
-        "_typeIds",
         "_requestNonce",
         "_subjectSig",
         "_stakeDuration",
@@ -931,25 +886,21 @@ export const AttestationLogic: IContractMethodManifest = {
           type: "bytes32",
           index: 5
         },
-        _typeIds: {
-          type: "uint256[]",
-          index: 6
-        },
         _requestNonce: {
           type: "bytes32",
-          index: 7
+          index: 6
         },
         _subjectSig: {
           type: "bytes",
-          index: 8
+          index: 7
         },
         _stakeDuration: {
           type: "uint256",
-          index: 9
+          index: 8
         },
         _delegationSig: {
           type: "bytes",
-          index: 10
+          index: 9
         }
       }
     },
@@ -1090,7 +1041,7 @@ export const AttestationLogicUpgradeMode: IContractMethodManifest = {
     },
 
     proxyWriteAttestation: {
-      args_arr: ["_subject", "_attester", "_requester", "_dataHash", "_typeIds", "_timestamp"],
+      args_arr: ["_subject", "_attester", "_requester", "_dataHash", "_timestamp"],
       args: {
         _subject: {
           type: "address",
@@ -1108,13 +1059,9 @@ export const AttestationLogicUpgradeMode: IContractMethodManifest = {
           type: "bytes32",
           index: 3
         },
-        _typeIds: {
-          type: "uint256[]",
-          index: 4
-        },
         _timestamp: {
           type: "uint256",
-          index: 5
+          index: 4
         }
       }
     }
@@ -2949,7 +2896,7 @@ export const SafeMath: IContractMethodManifest = {
 export const SigningLogic: IContractMethodManifest = {
   methods: {
     generateRequestAttestationSchemaHash: {
-      args_arr: ["_subject", "_attester", "_requester", "_dataHash", "_typeIds", "_nonce"],
+      args_arr: ["_subject", "_attester", "_requester", "_dataHash", "_nonce"],
       args: {
         _subject: {
           type: "address",
@@ -2967,13 +2914,9 @@ export const SigningLogic: IContractMethodManifest = {
           type: "bytes32",
           index: 3
         },
-        _typeIds: {
-          type: "uint256[]",
-          index: 4
-        },
         _nonce: {
           type: "bytes32",
-          index: 5
+          index: 4
         }
       }
     },
@@ -3012,7 +2955,7 @@ export const SigningLogic: IContractMethodManifest = {
       }
     },
     generateAttestForDelegationSchemaHash: {
-      args_arr: ["_subject", "_requester", "_reward", "_paymentNonce", "_dataHash", "_typeIds", "_requestNonce"],
+      args_arr: ["_subject", "_requester", "_reward", "_paymentNonce", "_dataHash", "_requestNonce"],
       args: {
         _subject: {
           type: "address",
@@ -3034,13 +2977,9 @@ export const SigningLogic: IContractMethodManifest = {
           type: "bytes32",
           index: 4
         },
-        _typeIds: {
-          type: "uint256[]",
-          index: 5
-        },
         _requestNonce: {
           type: "bytes32",
-          index: 6
+          index: 5
         }
       }
     },
@@ -3062,7 +3001,7 @@ export const SigningLogic: IContractMethodManifest = {
       }
     },
     generateStakeForDelegationSchemaHash: {
-      args_arr: ["_subject", "_value", "_paymentNonce", "_dataHash", "_typeIds", "_requestNonce", "_stakeDuration"],
+      args_arr: ["_subject", "_value", "_paymentNonce", "_dataHash", "_requestNonce", "_stakeDuration"],
       args: {
         _subject: {
           type: "address",
@@ -3080,17 +3019,13 @@ export const SigningLogic: IContractMethodManifest = {
           type: "bytes32",
           index: 3
         },
-        _typeIds: {
-          type: "uint256[]",
-          index: 4
-        },
         _requestNonce: {
           type: "bytes32",
-          index: 5
+          index: 4
         },
         _stakeDuration: {
           type: "uint256",
-          index: 6
+          index: 5
         }
       }
     },
@@ -3177,7 +3112,7 @@ export const SigningLogicInterface: IContractMethodManifest = {
       }
     },
     generateRequestAttestationSchemaHash: {
-      args_arr: ["_subject", "_attester", "_requester", "_dataHash", "_typeIds", "_nonce"],
+      args_arr: ["_subject", "_attester", "_requester", "_dataHash", "_nonce"],
       args: {
         _subject: {
           type: "address",
@@ -3195,18 +3130,14 @@ export const SigningLogicInterface: IContractMethodManifest = {
           type: "bytes32",
           index: 3
         },
-        _typeIds: {
-          type: "uint256[]",
-          index: 4
-        },
         _nonce: {
           type: "bytes32",
-          index: 5
+          index: 4
         }
       }
     },
     generateAttestForDelegationSchemaHash: {
-      args_arr: ["_subject", "_requester", "_reward", "_paymentNonce", "_dataHash", "_typeIds", "_requestNonce"],
+      args_arr: ["_subject", "_requester", "_reward", "_paymentNonce", "_dataHash", "_requestNonce"],
       args: {
         _subject: {
           type: "address",
@@ -3228,13 +3159,9 @@ export const SigningLogicInterface: IContractMethodManifest = {
           type: "bytes32",
           index: 4
         },
-        _typeIds: {
-          type: "uint256[]",
-          index: 5
-        },
         _requestNonce: {
           type: "bytes32",
-          index: 6
+          index: 5
         }
       }
     },
@@ -3256,7 +3183,7 @@ export const SigningLogicInterface: IContractMethodManifest = {
       }
     },
     generateStakeForDelegationSchemaHash: {
-      args_arr: ["_subject", "_value", "_paymentNonce", "_dataHash", "_typeIds", "_requestNonce", "_stakeDuration"],
+      args_arr: ["_subject", "_value", "_paymentNonce", "_dataHash", "_requestNonce", "_stakeDuration"],
       args: {
         _subject: {
           type: "address",
@@ -3274,17 +3201,13 @@ export const SigningLogicInterface: IContractMethodManifest = {
           type: "bytes32",
           index: 3
         },
-        _typeIds: {
-          type: "uint256[]",
-          index: 4
-        },
         _requestNonce: {
           type: "bytes32",
-          index: 5
+          index: 4
         },
         _stakeDuration: {
           type: "uint256",
-          index: 6
+          index: 5
         }
       }
     },
@@ -3379,7 +3302,7 @@ export const SigningLogicInterface: IContractMethodManifest = {
 export const SigningLogicLegacy: IContractMethodManifest = {
   methods: {
     generateRequestAttestationSchemaHash: {
-      args_arr: ["_subject", "_attester", "_requester", "_dataHash", "_typeIds", "_nonce"],
+      args_arr: ["_subject", "_attester", "_requester", "_dataHash", "_nonce"],
       args: {
         _subject: {
           type: "address",
@@ -3397,13 +3320,9 @@ export const SigningLogicLegacy: IContractMethodManifest = {
           type: "bytes32",
           index: 3
         },
-        _typeIds: {
-          type: "uint256[]",
-          index: 4
-        },
         _nonce: {
           type: "bytes32",
-          index: 5
+          index: 4
         }
       }
     },
@@ -3442,7 +3361,7 @@ export const SigningLogicLegacy: IContractMethodManifest = {
       }
     },
     generateAttestForDelegationSchemaHash: {
-      args_arr: ["_subject", "_requester", "_reward", "_paymentNonce", "_dataHash", "_typeIds", "_requestNonce"],
+      args_arr: ["_subject", "_requester", "_reward", "_paymentNonce", "_dataHash", "_requestNonce"],
       args: {
         _subject: {
           type: "address",
@@ -3464,13 +3383,9 @@ export const SigningLogicLegacy: IContractMethodManifest = {
           type: "bytes32",
           index: 4
         },
-        _typeIds: {
-          type: "uint256[]",
-          index: 5
-        },
         _requestNonce: {
           type: "bytes32",
-          index: 6
+          index: 5
         }
       }
     },
@@ -3492,7 +3407,7 @@ export const SigningLogicLegacy: IContractMethodManifest = {
       }
     },
     generateStakeForDelegationSchemaHash: {
-      args_arr: ["_subject", "_value", "_paymentNonce", "_dataHash", "_typeIds", "_requestNonce", "_stakeDuration"],
+      args_arr: ["_subject", "_value", "_paymentNonce", "_dataHash", "_requestNonce", "_stakeDuration"],
       args: {
         _subject: {
           type: "address",
@@ -3510,17 +3425,13 @@ export const SigningLogicLegacy: IContractMethodManifest = {
           type: "bytes32",
           index: 3
         },
-        _typeIds: {
-          type: "uint256[]",
-          index: 4
-        },
         _requestNonce: {
           type: "bytes32",
-          index: 5
+          index: 4
         },
         _stakeDuration: {
           type: "uint256",
-          index: 6
+          index: 5
         }
       }
     },

--- a/ts_test/AttestationLogic.ts
+++ b/ts_test/AttestationLogic.ts
@@ -146,8 +146,6 @@ contract("AttestationLogic", function(
     await attestationLogic.setAdmin(mockAdmin, {from: mockOwner})
 
     await Promise.all([
-      attestationLogic.createType("phone", {from: mockAdmin}),
-      attestationLogic.createType("email", {from: mockAdmin}),
       // token.gift(alice),
       token.gift(david, new BigNumber("1e18")),
       token.gift(david, new BigNumber("1e18")),
@@ -180,7 +178,6 @@ contract("AttestationLogic", function(
       bob,
       david,
       combinedDataHash,
-      [0, 1],
       nonce,
     )}
   );
@@ -202,7 +199,6 @@ contract("AttestationLogic", function(
       bob,
       david,
       combinedDataHash,
-      [0, 1],
       nonce,
     )}
   );
@@ -215,7 +211,6 @@ contract("AttestationLogic", function(
       new BigNumber(web3.toWei(1, "ether")).toString(10),
       nonce,
       combinedDataHash,
-      [0, 1],
       nonce,
     )}
   );
@@ -240,7 +235,6 @@ contract("AttestationLogic", function(
       paymentNonce: nonce,
       requesterSig: tokenReleaseSig,
       dataHash: combinedDataHash,
-      typeIds: [0, 1],
       requestNonce: nonce,
       subjectSig: subjectSig,
       from: bob
@@ -257,7 +251,6 @@ contract("AttestationLogic", function(
         paymentNonce,
         requesterSig,
         dataHash,
-        typeIds,
         requestNonce,
         subjectSig,
         from
@@ -273,7 +266,6 @@ contract("AttestationLogic", function(
         paymentNonce,
         requesterSig,
         dataHash,
-        typeIds,
         requestNonce,
         subjectSig,
         {
@@ -305,10 +297,6 @@ contract("AttestationLogic", function(
       await attest({from: alice}).should.be.rejectedWith(EVMThrow);
     });
 
-    it("fails if invalid type", async () => {
-      await attest({typeIds: [1, 2]}).should.be.rejectedWith(EVMThrow);
-    });
-
     it("fails if no account for subject", async () => {
       const unrelatedWallet = ethereumjsWallet.generate()
       await attest({
@@ -320,7 +308,6 @@ contract("AttestationLogic", function(
               attestDefaults.attester,
               attestDefaults.requester,
               attestDefaults.dataHash,
-              attestDefaults.typeIds,
               attestDefaults.requestNonce,
           )}
         )
@@ -334,7 +321,6 @@ contract("AttestationLogic", function(
       attesterId: BigNumber.BigNumber;
       requesterId: BigNumber.BigNumber;
       dataHash: string;
-      typeIds: BigNumber.BigNumber[];
       stakeValue: BigNumber.BigNumber;
       expiresAt: BigNumber.BigNumber;
     }
@@ -357,8 +343,6 @@ contract("AttestationLogic", function(
       matchingLog.args.attesterId.should.be.bignumber.equal(bobId);
       matchingLog.args.requesterId.should.be.bignumber.equal(davidId);
       matchingLog.args.dataHash.should.be.equal(attestDefaults.dataHash);
-      new BigNumber(matchingLog.args.typeIds[0]).toNumber().should.be.equal(attestDefaults.typeIds[0])
-      new BigNumber(matchingLog.args.typeIds[1]).toNumber().should.be.equal(attestDefaults.typeIds[1])
       matchingLog.args.stakeValue.should.be.bignumber.equal(0);
       matchingLog.args.expiresAt.should.be.bignumber.equal(0);
     });
@@ -385,75 +369,10 @@ contract("AttestationLogic", function(
               bob,
               david,
               combinedDataHash,
-              [0, 1],
               differentNonce,
             )}
         )
       }).should.be.fulfilled;
-    });
-
-    it("accepts a valid attestation for 9 traits", async () => {
-      let tempTypes = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
-      for (let i in tempTypes) {
-        await attestationLogic.createType(tempTypes[i], {from: mockAdmin})
-      }
-      await attest({
-          paymentNonce: differentNonce,
-          requesterSig: ethSigUtil.signTypedDataLegacy(
-            davidPrivkey,
-            {data: getFormattedTypedDataReleaseTokens(
-              david,
-              bob,
-              new BigNumber(web3.toWei(1, "ether")).toString(10),
-              differentNonce,
-            )}
-          ),
-          typeIds: [0, 1, 2, 3, 5, 6, 7, 8, 9],
-          requestNonce: differentNonce,
-          subjectSig: ethSigUtil.signTypedDataLegacy(
-              alicePrivkey,
-              {data: getFormattedTypedDataAttestationRequest(
-                alice,
-                bob,
-                david,
-                combinedDataHash,
-                [0, 1, 2, 3, 5, 6, 7, 8, 9],
-                differentNonce,
-              )}
-          )
-      }).should.be.fulfilled;
-    });
-
-    it("rejects a valid second attestation for 9 traits if one not valid", async () => {
-      let tempTypes = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
-      for (let i in tempTypes) {
-        await attestationLogic.createType(tempTypes[i], {from: mockAdmin})
-      }
-      await attest({
-          paymentNonce: differentNonce,
-          requesterSig: ethSigUtil.signTypedDataLegacy(
-            davidPrivkey,
-            {data: getFormattedTypedDataReleaseTokens(
-              david,
-              bob,
-              new BigNumber(web3.toWei(1, "ether")).toString(10),
-              differentNonce,
-            )}
-          ),
-          typeIds: [0, 1, 2, 3, 5, 6, 7, 8, 9],
-          requestNonce: differentNonce,
-          subjectSig: ethSigUtil.signTypedDataLegacy(
-              alicePrivkey,
-              {data: getFormattedTypedDataAttestationRequest(
-                alice,
-                bob,
-                david,
-                combinedDataHash,
-                [0, 1, 2, 3, 5, 6, 7, 8, 9],
-                differentNonce,
-              )}
-          )
-      }).should.be.rejectedWith(EVMThrow);
     });
 
 
@@ -548,7 +467,6 @@ contract("AttestationLogic", function(
                 bob,
                 david,
                 attestDefaults.dataHash,
-                attestDefaults.typeIds,
                 differentNonce,
               )}
           )
@@ -591,10 +509,6 @@ contract("AttestationLogic", function(
 
     it("rejects attestations with for an invalid data hash", async () => {
       await attest({ dataHash: emailDataHash}).should.be.rejectedWith(EVMThrow);
-    });
-
-    it("rejects attestations with for an invalid type ids", async () => {
-      await attest({ typeIds: [1]}).should.be.rejectedWith(EVMThrow);
     });
 
     it("rejects attestations with for an invalid payment nonce", async () => {
@@ -823,7 +737,6 @@ contract("AttestationLogic", function(
       paymentNonce: nonce,
       requesterSig: tokenReleaseSig,
       dataHash: combinedDataHash,
-      typeIds: [0, 1],
       requestNonce: nonce,
       subjectSig: subjectSig,
       delegationSig: attesterDelegationSig,
@@ -841,7 +754,6 @@ contract("AttestationLogic", function(
         paymentNonce,
         requesterSig,
         dataHash,
-        typeIds,
         requestNonce,
         subjectSig,
         delegationSig,
@@ -859,7 +771,6 @@ contract("AttestationLogic", function(
         paymentNonce,
         requesterSig,
         dataHash,
-        typeIds,
         requestNonce,
         subjectSig,
         delegationSig,
@@ -929,14 +840,6 @@ contract("AttestationLogic", function(
       ).should.be.rejectedWith(EVMThrow);
     });
 
-    it("rejects an attestation if the type hash is wrong", async () => {
-      await attestFor(
-        {
-          typeIds: [1]
-        }
-      ).should.be.rejectedWith(EVMThrow);
-    });
-
     it("rejects an attestation if the request nonce is wrong", async () => {
       await attestFor(
         {
@@ -957,7 +860,6 @@ contract("AttestationLogic", function(
       paymentNonce: nonce,
       requesterSig: tokenReleaseSig,
       dataHash: combinedDataHash,
-      typeIds: [0, 1],
       requestNonce: nonce,
       subjectSig: subjectSig,
       from: bob
@@ -974,7 +876,6 @@ contract("AttestationLogic", function(
         paymentNonce,
         requesterSig,
         dataHash,
-        typeIds,
         requestNonce,
         subjectSig,
         from
@@ -990,7 +891,6 @@ contract("AttestationLogic", function(
         paymentNonce,
         requesterSig,
         dataHash,
-        typeIds,
         requestNonce,
         subjectSig,
         {

--- a/ts_test/AttestationLogicUpgradeMode.ts
+++ b/ts_test/AttestationLogicUpgradeMode.ts
@@ -92,7 +92,6 @@ contract("AttestationLogicUpgradeMode", function(
 
   const merkleTree = HashingLogic.getMerkleTree([phoneData, emailData])
   const dataHash = bufferToHex(merkleTree.getRoot())
-  const typeIds = [0, 1];
 
   beforeEach(async () => {
     registry = await AccountRegistry.new(alice);
@@ -125,7 +124,6 @@ contract("AttestationLogicUpgradeMode", function(
         bob,
         david,
         dataHash,
-        typeIds,
         1526241724,
       ).should.be.fulfilled;
     });
@@ -136,7 +134,6 @@ contract("AttestationLogicUpgradeMode", function(
       attesterId: BigNumber.BigNumber;
       requesterId: BigNumber.BigNumber;
       dataHash: string;
-      typeIds: BigNumber.BigNumber[];
       stakeValue: BigNumber.BigNumber;
       expiresAt: BigNumber.BigNumber;
     }
@@ -148,7 +145,6 @@ contract("AttestationLogicUpgradeMode", function(
           bob,
           david,
           dataHash,
-          typeIds,
           1526241724,
         )
     ) as Web3.TransactionReceipt<any>) as Web3.TransactionReceipt<
@@ -167,8 +163,6 @@ contract("AttestationLogicUpgradeMode", function(
       matchingLog.args.attesterId.should.be.bignumber.equal(bobId);
       matchingLog.args.requesterId.should.be.bignumber.equal(davidId);
       matchingLog.args.dataHash.should.be.equal(dataHash);
-      new BigNumber(matchingLog.args.typeIds[0]).toNumber().should.be.equal(typeIds[0])
-      new BigNumber(matchingLog.args.typeIds[1]).toNumber().should.be.equal(typeIds[1])
       matchingLog.args.stakeValue.should.be.bignumber.equal(0);
       matchingLog.args.expiresAt.should.be.bignumber.equal(0);
     });
@@ -180,7 +174,6 @@ contract("AttestationLogicUpgradeMode", function(
         bob,
         david,
         dataHash,
-        typeIds,
         1526241724,
       ).should.be.rejectedWith(EVMThrow);
     });
@@ -190,7 +183,6 @@ contract("AttestationLogicUpgradeMode", function(
         bob,
         david,
         dataHash,
-        typeIds,
         1526241724,
         {from: carl},
       ).should.be.rejectedWith(EVMThrow);

--- a/ts_test/AttestationStakingLogic.ts
+++ b/ts_test/AttestationStakingLogic.ts
@@ -141,7 +141,6 @@ contract("AttestationLogic", function(
     await attestationLogic.setAdmin(mockAdmin)
 
     await Promise.all([
-      attestationLogic.createType("creditworthy", {from: mockAdmin}),
       // token.gift(alice),
       token.gift(david, new BigNumber("2e18")),
       registry.createNewAccount(alice),
@@ -179,7 +178,6 @@ contract("AttestationLogic", function(
         new BigNumber(web3.toWei(1, "ether")).toString(10),
         nonceHash,
         combinedDataHash,
-        [0],
         nonceHash,
         oneYear - oneDay,
       )}
@@ -203,7 +201,6 @@ contract("AttestationLogic", function(
       david,
       alice,
       combinedDataHash,
-      [0],
       nonceHash,
     )}
   );
@@ -215,7 +212,6 @@ contract("AttestationLogic", function(
       david,
       alice,
       combinedDataHash,
-      [0],
       nonceHash,
     )}
   );
@@ -231,7 +227,6 @@ contract("AttestationLogic", function(
     paymentNonce: nonceHash,
     paymentSig: "",
     dataHash: combinedDataHash,
-    typeIds: [0],
     requestNonce: nonceHash,
     subjectSig: subjectSig,
     stakeDuration: oneYear - oneDay,
@@ -248,7 +243,6 @@ contract("AttestationLogic", function(
       paymentNonce,
       paymentSig,
       dataHash,
-      typeIds,
       requestNonce,
       subjectSig,
       stakeDuration,
@@ -264,7 +258,6 @@ contract("AttestationLogic", function(
       paymentNonce,
       paymentSig,
       dataHash,
-      typeIds,
       requestNonce,
       subjectSig,
       stakeDuration,
@@ -330,7 +323,6 @@ contract("AttestationLogic", function(
       attesterId: BigNumber.BigNumber;
       requesterId: BigNumber.BigNumber;
       dataHash: string;
-      typeIds: BigNumber.BigNumber[];
       stakeValue: BigNumber.BigNumber;
       expiresAt: BigNumber.BigNumber;
     }
@@ -353,7 +345,6 @@ contract("AttestationLogic", function(
       matchingLog.args.attesterId.should.be.bignumber.equal(davidId);
       matchingLog.args.requesterId.should.be.bignumber.equal(aliceId);
       matchingLog.args.dataHash.should.be.equal(stakeDefaults.dataHash);
-      new BigNumber(matchingLog.args.typeIds[0]).toNumber().should.be.equal(stakeDefaults.typeIds[0])
       matchingLog.args.stakeValue.should.be.bignumber.equal(stakeDefaults.value);
       matchingLog.args.expiresAt.should.be.bignumber.equal(new BigNumber(latestBlockTime() + oneYear - oneDay));
     });
@@ -372,26 +363,6 @@ contract("AttestationLogic", function(
         {
           paymentSig: tokenReleaseSig,
           stakeDuration: oneYear + oneDay,
-        }
-      ).should.be.rejectedWith(EVMThrow);
-    });
-
-    it("Fails if invalid trait type", async () => {
-      await stake(
-        {
-          paymentSig: tokenReleaseSig,
-          typeIds: [1],
-          subjectSig: ethSigUtil.signTypedDataLegacy(
-            alicePrivkey,
-            {data: getFormattedTypedDataAttestationRequest(
-              alice,
-              david,
-              alice,
-              combinedDataHash,
-              [1],
-              nonceHash,
-            )}
-          )
         }
       ).should.be.rejectedWith(EVMThrow);
     });
@@ -460,7 +431,6 @@ contract("AttestationLogic", function(
       paymentNonce: nonceHash,
       paymentSig: "",
       dataHash: combinedDataHash,
-      typeIds: [0],
       requestNonce: nonceHash,
       subjectSig: subjectSig,
       stakeDuration: oneYear - oneDay,
@@ -478,7 +448,6 @@ contract("AttestationLogic", function(
         paymentNonce,
         paymentSig,
         dataHash,
-        typeIds,
         requestNonce,
         subjectSig,
         stakeDuration,
@@ -496,7 +465,6 @@ contract("AttestationLogic", function(
         paymentNonce,
         paymentSig,
         dataHash,
-        typeIds,
         requestNonce,
         subjectSig,
         stakeDuration,
@@ -572,16 +540,6 @@ contract("AttestationLogic", function(
           paymentSig: tokenReleaseSig,
           delegationSig: stakerDelegationSig,
           dataHash: 'invalidHash'
-        }
-      ).should.be.rejectedWith(EVMThrow);
-    });
-
-    it("rejects a stake if the type hash is wrong", async () => {
-      await stakeFor(
-        {
-          paymentSig: tokenReleaseSig,
-          delegationSig: stakerDelegationSig,
-          typeIds: [1]
         }
       ).should.be.rejectedWith(EVMThrow);
     });

--- a/ts_test/helpers/signingLogic.ts
+++ b/ts_test/helpers/signingLogic.ts
@@ -11,8 +11,6 @@ interface IFormattedTypedData {
     domain: {
       name: string
       version: string
-      chainId: number
-      verifyingContract: string
     }
     message: {[key: string]: string},
 }
@@ -27,7 +25,6 @@ export const getFormattedTypedDataAttestationRequest= (
   attester: string,
   requester: string,
   dataHash: string,
-  typeIds: number[],
   requestNonce: string,
 ): IFormattedTypedData => {
   return {
@@ -43,7 +40,6 @@ export const getFormattedTypedDataAttestationRequest= (
         { name: 'attester', type: 'address'},
         { name: 'requester', type: 'address'},
         { name: 'dataHash', type: 'bytes32'},
-        { name: 'typeHash', type: 'bytes32'},
         { name: 'nonce', type: 'bytes32'}
       ]
     },
@@ -51,17 +47,12 @@ export const getFormattedTypedDataAttestationRequest= (
     domain: {
       name: 'Bloom',
       version: '1',
-      // Rinkeby
-      chainId: 4,
-      // Dummy contract address for testing
-      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
     },
     message: {
       subject: subject,
       attester: attester,
       requester: requester,
       dataHash: dataHash,
-      typeHash: soliditySha3({ type: 'uint256[]', value: typeIds }),
       nonce: requestNonce
     }
   }
@@ -88,10 +79,6 @@ export const getFormattedTypedDataAddAddress = (
     domain: {
       name: 'Bloom',
       version: '1',
-      // Rinkeby
-      chainId: 4,
-      // Dummy contract address for testing
-      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
     },
     message: {
       sender: sender,
@@ -125,10 +112,6 @@ export const getFormattedTypedDataReleaseTokens = (
     domain: {
       name: 'Bloom',
       version: '1',
-      // Rinkeby
-      chainId: 4,
-      // Dummy contract address for testing
-      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
     },
     message: {
       sender: sender,
@@ -145,7 +128,6 @@ export const getFormattedTypedDataAttestFor = (
   reward: string,
   paymentNonce: string,
   dataHash: string,
-  typeIds: number[],
   requestNonce: string,
 ): IFormattedTypedData => {
   return {
@@ -162,7 +144,6 @@ export const getFormattedTypedDataAttestFor = (
         { name: 'reward', type: 'uint256'},
         { name: 'paymentNonce', type: 'bytes32'},
         { name: 'dataHash', type: 'bytes32'},
-        { name: 'typeHash', type: 'bytes32'},
         { name: 'requestNonce', type: 'bytes32'},
       ]
     },
@@ -170,10 +151,6 @@ export const getFormattedTypedDataAttestFor = (
     domain: {
       name: 'Bloom',
       version: '1',
-      // Rinkeby
-      chainId: 4,
-      // Dummy contract address for testing
-      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
     },
     message: {
       subject: subject,
@@ -181,7 +158,6 @@ export const getFormattedTypedDataAttestFor = (
       reward: reward,
       paymentNonce: paymentNonce,
       dataHash: dataHash,
-      typeHash: soliditySha3({ type: 'uint256[]', value: typeIds }),
       requestNonce: requestNonce,
     }
   }
@@ -210,10 +186,6 @@ export const getFormattedTypedDataContestFor = (
     domain: {
       name: 'Bloom',
       version: '1',
-      // Rinkeby
-      chainId: 4,
-      // Dummy contract address for testing
-      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
     },
     message: {
       requester: requester,
@@ -228,7 +200,6 @@ export const getFormattedTypedDataStakeFor = (
   value: string,
   paymentNonce: string,
   dataHash: string,
-  typeIds: number[],
   requestNonce: string,
   stakeDuration: number,
 ): IFormattedTypedData => {
@@ -245,7 +216,6 @@ export const getFormattedTypedDataStakeFor = (
         { name: 'value', type: 'uint256'},
         { name: 'paymentNonce', type: 'bytes32'},
         { name: 'dataHash', type: 'bytes32'},
-        { name: 'typeHash', type: 'bytes32'},
         { name: 'requestNonce', type: 'bytes32'},
         { name: 'stakeDuration', type: 'uint256'},
       ]
@@ -254,17 +224,12 @@ export const getFormattedTypedDataStakeFor = (
     domain: {
       name: 'Bloom',
       version: '1',
-      // Rinkeby
-      chainId: 4,
-      // Dummy contract address for testing
-      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
     },
     message: {
       subject: subject,
       value: value,
       paymentNonce: paymentNonce,
       dataHash: dataHash,
-      typeHash: soliditySha3({ type: 'uint256[]', value: typeIds }),
       requestNonce: requestNonce,
       stakeDuration: stakeDuration.toString(10),
     }
@@ -292,10 +257,6 @@ export const getFormattedTypedDataRevokeStakeFor = (
     domain: {
       name: 'Bloom',
       version: '1',
-      // Rinkeby
-      chainId: 4,
-      // Dummy contract address for testing
-      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
     },
     message: {
       subjectId: subjectId.toString(10),
@@ -329,10 +290,6 @@ export const getFormattedTypedDataVoteFor = (
     domain: {
       name: 'Bloom',
       version: '1',
-      // Rinkeby
-      chainId: 4,
-      // Dummy contract address for testing
-      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
     },
     message: {
       choice: choice.toString(10),
@@ -366,10 +323,6 @@ export const getFormattedTypedDataLockupTokensFor = (
     domain: {
       name: 'Bloom',
       version: '1',
-      // Rinkeby
-      chainId: 4,
-      // Dummy contract address for testing
-      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
     },
     message: {
       sender: sender,

--- a/ts_test/helpers/signingLogicLegacy.ts
+++ b/ts_test/helpers/signingLogicLegacy.ts
@@ -13,7 +13,6 @@ export const getFormattedTypedDataAttestationRequest= (
   attester: string,
   requester: string,
   dataHash: string,
-  typeIds: number[],
   requestNonce: string,
 ): ITypedDataParam[] => {
   return [
@@ -21,11 +20,6 @@ export const getFormattedTypedDataAttestationRequest= (
       {type: 'address', name: 'attester', value: attester},
       {type: 'address', name: 'requester', value: requester},
       {type: 'bytes32', name: 'dataHash', value: dataHash},
-      {
-        type: 'bytes32',
-        name: 'typeHash',
-        value: HashingLogic.hashAttestationTypes(typeIds),
-      },
       {type: 'bytes32', name: 'nonce', value: requestNonce},
   ]
 }
@@ -61,7 +55,6 @@ export const getFormattedTypedDataAttestFor = (
   reward: string,
   paymentNonce: string,
   dataHash: string,
-  typeIds: number[],
   requestNonce: string,
 ): ITypedDataParam[] => {
   return [
@@ -71,11 +64,6 @@ export const getFormattedTypedDataAttestFor = (
       {type: 'uint256', name: 'reward', value: reward},
       {type: 'bytes32', name: 'paymentNonce', value: paymentNonce},
       {type: 'bytes32', name: 'dataHash', value: dataHash},
-      {
-        type: 'bytes32',
-        name: 'typeHash',
-        value: HashingLogic.hashAttestationTypes(typeIds),
-      },
       {type: 'bytes32', name: 'requestNonce', value: requestNonce},
   ]
 }
@@ -98,7 +86,6 @@ export const getFormattedTypedDataStakeFor = (
   value: string,
   paymentNonce: string,
   dataHash: string,
-  typeIds: number[],
   requestNonce: string,
   stakeDuration: number,
 ): ITypedDataParam[] => {
@@ -108,13 +95,8 @@ export const getFormattedTypedDataStakeFor = (
       {type: 'uint256', name: 'value', value: value},
       {type: 'bytes32', name: 'paymentNonce', value: paymentNonce},
       {type: 'bytes32', name: 'dataHash', value: dataHash},
-      {
-        type: 'bytes32',
-        name: 'typeHash',
-        value: HashingLogic.hashAttestationTypes(typeIds),
-      },
       {type: 'bytes32', name: 'requestNonce', value: requestNonce},
-      {type: 'uint256', name: 'stakeDuration', value: stakeDuration},
+      {type: 'uint256', name: 'stakeDuration', value: stakeDuration.toString(10)},
   ]
 }
 


### PR DESCRIPTION
Public typeIds emitted by an attestation can lead to metadata gathering about BloomID users. Instead we should allow users to selectively share the attestation types by including them in the merkle tree.