### PR TITLE
write and test batchInitializer contract

### DIFF
--- a/contracts/BatchInitializer.sol
+++ b/contracts/BatchInitializer.sol
@@ -1,0 +1,91 @@
+pragma solidity 0.4.24;
+
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./AccountRegistryLogic.sol";
+import "./AttestationLogic.sol";
+import "./TokenEscrowMarketplace.sol";
+import "./Initializable.sol";
+
+contract BatchInitializer is Ownable{
+
+  AccountRegistryLogic public registryLogic;
+  AttestationLogic public attestationLogic;
+  address public admin;
+
+  constructor(
+    AttestationLogic _attestationLogic,
+    AccountRegistryLogic _registryLogic
+    ) public {
+    attestationLogic = _attestationLogic;
+    registryLogic = _registryLogic;
+    admin = owner;
+  }
+
+  event linkSkipped(address currentAddress, address newAddress);
+
+  /**
+   * @dev Restricted to admin
+   */
+  modifier onlyAdmin {
+    require(msg.sender == admin);
+    _;
+  }
+
+  /**
+   * @notice Change the address of the admin, who has the privilege to create new accounts
+   * @dev Restricted to AccountRegistry owner and new admin address cannot be 0x0
+   * @param _newAdmin Address of new admin
+   */
+  function setAdmin(address _newAdmin) external onlyOwner {
+    admin = _newAdmin;
+  }
+
+  function setRegistryLogic(AccountRegistryLogic _newRegistryLogic) external onlyOwner {
+    registryLogic = _newRegistryLogic;
+  }
+
+  function setAttestationLogic(AttestationLogic _newAttestationLogic) external onlyOwner {
+    attestationLogic = _newAttestationLogic;
+  }
+
+  function setTokenEscrowMarketplace(TokenEscrowMarketplace _newMarketplace) external onlyOwner {
+    attestationLogic.setTokenEscrowMarketplace(_newMarketplace);
+  }
+
+  function endInitialization(Initializable _initializable) external onlyOwner {
+    _initializable.endInitialization();
+  }
+
+  function batchLinkAddresses(address[] _currentAddresses, address[] _newAddresses) external onlyAdmin {
+    require(_currentAddresses.length == _newAddresses.length);
+    for (uint256 i = 0; i < _currentAddresses.length; i++) {
+      if (registryLogic.linkIds(_newAddresses[i]) > 0) {
+        emit linkSkipped(_currentAddresses[i], _newAddresses[i]);
+      } else {
+        registryLogic.migrateLink(_currentAddresses[i], _newAddresses[i]);
+      }
+    }
+  }
+
+  function batchMigrateAttestations(
+    address[] _requesters,
+    address[] _attesters,
+    address[] _subjects,
+    bytes32[] _dataHashes
+    ) external onlyAdmin {
+    require(
+      _requesters.length == _attesters.length &&
+      _requesters.length == _subjects.length &&
+      _requesters.length == _dataHashes.length
+      );
+    // This loop will fail if args don't all have equal length
+    for (uint256 i = 0; i < _requesters.length; i++) {
+      attestationLogic.migrateAttestation(
+        _requesters[i],
+        _attesters[i],
+        _subjects[i],
+        _dataHashes[i]
+        );
+    }
+  }
+}

--- a/generate.ts
+++ b/generate.ts
@@ -28,7 +28,7 @@ interface UnknownMember {
   type: string
 }
 
-type SolidityType = "address" | "address[]" | "bool" | "bytes" | "bytes32" | "string" | "uint8" | "uint16" | "uint64" | "uint256" | "uint256[]"
+type SolidityType = "address" | "address[]" | "bool" | "bytes" | "bytes32" | "bytes32[]" | "string" | "uint8" | "uint16" | "uint64" | "uint256" | "uint256[]"
 
 interface FunctionMemberInput {
   name: string
@@ -234,6 +234,8 @@ function translateType(type: SolidityType, options = { UInt: "UInt" }): string {
       return "string"
     case "bytes32":
       return "string"
+    case "bytes32[]":
+      return "string[]"
     case "uint8":
     case "uint16":
     case "uint64":

--- a/generate_method_manifest.ts
+++ b/generate_method_manifest.ts
@@ -28,7 +28,7 @@ interface UnknownMember {
   type: string
 }
 
-type SolidityType = "address" | "address[]" | "bool" | "bytes" | "bytes32" | "string" | "uint8" | "uint16" | "uint64" | "uint256" | "uint256[]"
+type SolidityType = "address" | "address[]" | "bool" | "bytes" | "bytes32" | "bytes32[]" | "string" | "uint8" | "uint16" | "uint64" | "uint256" | "uint256[]"
 
 interface FunctionMemberInput {
   name: string
@@ -173,6 +173,8 @@ function translateType(type: SolidityType, options = { UInt: "UInt" }): string {
       return "string"
     case "bytes32":
       return "string"
+    case "bytes32[]":
+      return "string[]"
     case "uint8":
     case "uint16":
     case "uint64":

--- a/method_manifest.ts
+++ b/method_manifest.ts
@@ -20,6 +20,7 @@ export enum EContractNames {
   "ApproveAndCallFallBack" = "ApproveAndCallFallBack",
   "AttestationLogic" = "AttestationLogic",
   "BasicToken" = "BasicToken",
+  "BatchInitializer" = "BatchInitializer",
   "BLT" = "BLT",
   "Controlled" = "Controlled",
   "ConvertLib" = "ConvertLib",
@@ -554,6 +555,116 @@ export const BasicToken: IContractMethodManifest = {
         _owner: {
           type: "address",
           index: 0
+        }
+      }
+    }
+  }
+}
+
+export const BatchInitializer: IContractMethodManifest = {
+  methods: {
+    attestationLogic: {
+      args_arr: [],
+      args: {}
+    },
+    owner: {
+      args_arr: [],
+      args: {}
+    },
+    registryLogic: {
+      args_arr: [],
+      args: {}
+    },
+    transferOwnership: {
+      args_arr: ["newOwner"],
+      args: {
+        newOwner: {
+          type: "address",
+          index: 0
+        }
+      }
+    },
+    admin: {
+      args_arr: [],
+      args: {}
+    },
+
+    setAdmin: {
+      args_arr: ["_newAdmin"],
+      args: {
+        _newAdmin: {
+          type: "address",
+          index: 0
+        }
+      }
+    },
+    setRegistryLogic: {
+      args_arr: ["_newRegistryLogic"],
+      args: {
+        _newRegistryLogic: {
+          type: "address",
+          index: 0
+        }
+      }
+    },
+    setAttestationLogic: {
+      args_arr: ["_newAttestationLogic"],
+      args: {
+        _newAttestationLogic: {
+          type: "address",
+          index: 0
+        }
+      }
+    },
+    setTokenEscrowMarketplace: {
+      args_arr: ["_newMarketplace"],
+      args: {
+        _newMarketplace: {
+          type: "address",
+          index: 0
+        }
+      }
+    },
+    endInitialization: {
+      args_arr: ["_initializable"],
+      args: {
+        _initializable: {
+          type: "address",
+          index: 0
+        }
+      }
+    },
+    batchLinkAddresses: {
+      args_arr: ["_currentAddresses", "_newAddresses"],
+      args: {
+        _currentAddresses: {
+          type: "address[]",
+          index: 0
+        },
+        _newAddresses: {
+          type: "address[]",
+          index: 1
+        }
+      }
+    },
+    batchMigrateAttestations: {
+      args_arr: ["_requesters", "_attesters", "_subjects", "_dataHashes"],
+      args: {
+        _requesters: {
+          type: "address[]",
+          index: 0
+        },
+        _attesters: {
+          type: "address[]",
+          index: 1
+        },
+        _subjects: {
+          type: "address[]",
+          index: 2
+        },
+        _dataHashes: {
+          type: "bytes32[]",
+          index: 3
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "yarn": "^1.3.2"
   },
   "dependencies": {
-    "@bloomprotocol/attestations-lib": "^0.4.3",
+    "@bloomprotocol/attestations-lib": "^3.0.2",
     "eth-gas-reporter": "^0.1.9",
     "eth-sig-util": "^2.0.1",
     "ethereumjs-util": "^5.1.2",

--- a/truffle.d.ts
+++ b/truffle.d.ts
@@ -43,6 +43,7 @@ interface Artifacts {
   require(name: "ApproveAndCallFallBack"): ApproveAndCallFallBackContract
   require(name: "AttestationLogic"): AttestationLogicContract
   require(name: "BasicToken"): BasicTokenContract
+  require(name: "BatchInitializer"): BatchInitializerContract
   require(name: "BLT"): BLTContract
   require(name: "Controlled"): ControlledContract
   require(name: "ConvertLib"): ConvertLibContract
@@ -567,6 +568,106 @@ export interface BasicTokenContract {
   new: (options?: TransactionOptions) => Promise<BasicTokenInstance>
   deployed(): Promise<BasicTokenInstance>
   at(address: string): BasicTokenInstance
+}
+
+export interface BatchInitializerInstance extends ContractInstance {
+  attestationLogic: {
+    (options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(options?: TransactionOptions): Promise<Address>
+    sendTransaction(options?: TransactionOptions): Promise<string>
+    estimateGas(options?: TransactionOptions): Promise<number>
+  }
+  owner: {
+    (options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(options?: TransactionOptions): Promise<Address>
+    sendTransaction(options?: TransactionOptions): Promise<string>
+    estimateGas(options?: TransactionOptions): Promise<number>
+  }
+  registryLogic: {
+    (options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(options?: TransactionOptions): Promise<Address>
+    sendTransaction(options?: TransactionOptions): Promise<string>
+    estimateGas(options?: TransactionOptions): Promise<number>
+  }
+  transferOwnership: {
+    (newOwner: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(newOwner: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    sendTransaction(newOwner: Address, options?: TransactionOptions): Promise<string>
+    estimateGas(newOwner: Address, options?: TransactionOptions): Promise<number>
+  }
+  admin: {
+    (options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(options?: TransactionOptions): Promise<Address>
+    sendTransaction(options?: TransactionOptions): Promise<string>
+    estimateGas(options?: TransactionOptions): Promise<number>
+  }
+
+  linkSkipped: Web3.EventFilterCreator<{ currentAddress: Address; newAddress: Address }>
+
+  OwnershipTransferred: Web3.EventFilterCreator<{ previousOwner: Address; newOwner: Address }>
+
+  setAdmin: {
+    (newAdmin: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(newAdmin: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    sendTransaction(newAdmin: Address, options?: TransactionOptions): Promise<string>
+    estimateGas(newAdmin: Address, options?: TransactionOptions): Promise<number>
+  }
+  setRegistryLogic: {
+    (newRegistryLogic: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(newRegistryLogic: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    sendTransaction(newRegistryLogic: Address, options?: TransactionOptions): Promise<string>
+    estimateGas(newRegistryLogic: Address, options?: TransactionOptions): Promise<number>
+  }
+  setAttestationLogic: {
+    (newAttestationLogic: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(newAttestationLogic: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    sendTransaction(newAttestationLogic: Address, options?: TransactionOptions): Promise<string>
+    estimateGas(newAttestationLogic: Address, options?: TransactionOptions): Promise<number>
+  }
+  setTokenEscrowMarketplace: {
+    (newMarketplace: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(newMarketplace: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    sendTransaction(newMarketplace: Address, options?: TransactionOptions): Promise<string>
+    estimateGas(newMarketplace: Address, options?: TransactionOptions): Promise<number>
+  }
+  endInitialization: {
+    (initializable: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(initializable: Address, options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    sendTransaction(initializable: Address, options?: TransactionOptions): Promise<string>
+    estimateGas(initializable: Address, options?: TransactionOptions): Promise<number>
+  }
+  batchLinkAddresses: {
+    (currentAddresses: Address[], newAddresses: Address[], options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    call(currentAddresses: Address[], newAddresses: Address[], options?: TransactionOptions): Promise<Web3.TransactionReceipt>
+    sendTransaction(currentAddresses: Address[], newAddresses: Address[], options?: TransactionOptions): Promise<string>
+    estimateGas(currentAddresses: Address[], newAddresses: Address[], options?: TransactionOptions): Promise<number>
+  }
+  batchMigrateAttestations: {
+    (requesters: Address[], attesters: Address[], subjects: Address[], dataHashes: string[], options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >
+    call(
+      requesters: Address[],
+      attesters: Address[],
+      subjects: Address[],
+      dataHashes: string[],
+      options?: TransactionOptions
+    ): Promise<Web3.TransactionReceipt>
+    sendTransaction(
+      requesters: Address[],
+      attesters: Address[],
+      subjects: Address[],
+      dataHashes: string[],
+      options?: TransactionOptions
+    ): Promise<string>
+    estimateGas(requesters: Address[], attesters: Address[], subjects: Address[], dataHashes: string[], options?: TransactionOptions): Promise<number>
+  }
+}
+
+export interface BatchInitializerContract {
+  new: (attestationLogic: Address, registryLogic: Address, options?: TransactionOptions) => Promise<BatchInitializerInstance>
+  deployed(): Promise<BatchInitializerInstance>
+  at(address: string): BatchInitializerInstance
 }
 
 export interface BLTInstance extends ContractInstance {

--- a/ts_test/AttestationLogic.ts
+++ b/ts_test/AttestationLogic.ts
@@ -56,30 +56,8 @@ contract("AttestationLogic", function([alice, bob, carl, david, ellen, initializ
     throw new Error("Mnemonic used for truffle tests out of sync?")
   }
 
-  const phoneData: HashingLogic.IAttestationData = {
-    type: "phone",
-    provider: "Bloom",
-    data: "12223334444",
-    nonce: uuid(),
-    version: "1.0.0"
-  }
-
-  const emailData: HashingLogic.IAttestationData = {
-    type: "email",
-    provider: "Bloom",
-    data: "abc@google.com",
-    nonce: uuid(),
-    version: "1.0.0"
-  }
-
-  const phoneOnlyMerkleTree = HashingLogic.getMerkleTree([phoneData])
-  const emailOnlyMerkleTree = HashingLogic.getMerkleTree([emailData])
-
-  const phoneDataHash = bufferToHex(phoneOnlyMerkleTree.getRoot())
-  const emailDataHash = bufferToHex(emailOnlyMerkleTree.getRoot())
-
-  const merkleTree = HashingLogic.getMerkleTree([phoneData, emailData])
-  const combinedDataHash = bufferToHex(merkleTree.getRoot())
+  const emailDataHash = '0xd1696aa0222c2ee299efa58d265eaecc4677d8c88cb3a5c7e60bc5957fff514a'
+  const combinedDataHash = '0xe72cf1f9a85fbc529cd17cded83d0021beb12359c7f238276d8e20aea603e928'
 
   let nonce: string
   let differentNonce: string

--- a/ts_test/BatchInitializer.ts
+++ b/ts_test/BatchInitializer.ts
@@ -1,0 +1,245 @@
+import * as BigNumber from "bignumber.js"
+import * as Web3 from "web3"
+import * as ethereumjsWallet from "ethereumjs-wallet"
+const walletTools = require("ethereumjs-wallet")
+const { privateToAddress } = require("ethereumjs-util")
+import { signAddress } from "./../src/signAddress"
+const ethSigUtil = require("eth-sig-util")
+const { soliditySha3 } = require("web3-utils")
+const uuid = require("uuidv4")
+import { bufferToHex } from "ethereumjs-util"
+import { hashData } from "./../src/signData"
+
+import {
+  AttestationLogicInstance,
+  AccountRegistryLogicInstance,
+  TokenEscrowMarketplaceInstance,
+  MockBLTInstance,
+  BatchInitializerInstance
+} from "../truffle"
+import { EVMThrow } from "./helpers/EVMThrow"
+import * as ipfs from "./../src/ipfs"
+
+import { should } from "./test_setup"
+import { getFormattedTypedDataAddAddress } from "./helpers/signingLogicLegacy"
+import { HashingLogic } from "@bloomprotocol/attestations-lib"
+
+const AttestationLogic = artifacts.require("AttestationLogic")
+const TokenEscrowMarketplace = artifacts.require("TokenEscrowMarketplace")
+const AccountRegistryLogic = artifacts.require("AccountRegistryLogic")
+const BatchInitializer = artifacts.require("BatchInitializer")
+const BLT = artifacts.require("MockBLT")
+
+contract("BatchInitializer", function([owner, admin, unrelated]) {
+  let registryLogic: AccountRegistryLogicInstance
+  let batchInitializer: BatchInitializerInstance
+  let attestationLogic: AttestationLogicInstance
+  let tokenEscrowMarketplace: TokenEscrowMarketplaceInstance
+  let token: MockBLTInstance
+
+  interface addressLink {
+    currentAddress: string
+    newAddress: string
+  }
+
+  interface attestationMigration {
+    requester: string
+    attester: string
+    subject: string
+    dataHash: string
+  }
+
+  let testLinks: addressLink[] = []
+  for (let i = 0; i < 500; i++) {
+    testLinks.push({
+      currentAddress: ethereumjsWallet.generate().getAddressString(),
+      newAddress: ethereumjsWallet.generate().getAddressString()
+    })
+  }
+
+  let testAttestations: attestationMigration[] = []
+  for (let i = 0; i < 500; i++) {
+    testAttestations.push({
+      requester: ethereumjsWallet.generate().getAddressString(),
+      attester: ethereumjsWallet.generate().getAddressString(),
+      subject: ethereumjsWallet.generate().getAddressString(),
+      dataHash: HashingLogic.generateNonce()
+    })
+  }
+
+  beforeEach(async () => {
+    token = await BLT.new()
+    batchInitializer = await BatchInitializer.new("0x0", "0x0")
+    registryLogic = await AccountRegistryLogic.new(batchInitializer.address)
+    attestationLogic = await AttestationLogic.new(batchInitializer.address, "0x0")
+    tokenEscrowMarketplace = await TokenEscrowMarketplace.new(token.address, attestationLogic.address)
+    await batchInitializer.setAttestationLogic(attestationLogic.address)
+    await batchInitializer.setRegistryLogic(registryLogic.address)
+    await batchInitializer.setTokenEscrowMarketplace(tokenEscrowMarketplace.address)
+    await batchInitializer.setAdmin(admin)
+  })
+
+  describe("Configuration", async () => {
+    it("allows the owner to end initialization in attestation logic", async () => {
+      await batchInitializer.endInitialization(attestationLogic.address, {from: owner}).should.be.fulfilled
+    })
+    it("allows the owner to end initialization in registry", async () => {
+      await batchInitializer.endInitialization(registryLogic.address, {from: owner}).should.be.fulfilled
+    })
+
+    it("Fails if address points to unrelated contract", async () => {
+      await batchInitializer.endInitialization(tokenEscrowMarketplace.address, {from: owner}).should.be.rejectedWith(EVMThrow)
+    })
+
+    it("does not allow anyone else to end initialization", async () => {
+      await batchInitializer.endInitialization(registryLogic.address, {from: unrelated}).should.be.rejectedWith(EVMThrow)
+    })
+  })
+
+  describe("Batch loading accounts", async () => {
+    it("allows the admin to batch load accounts links", async () => {
+      const numlinks = 50
+      const currentAddresses = testLinks.slice(0, numlinks).map(a => a.currentAddress)
+      const newAddresses = testLinks.slice(0, numlinks).map(a => a.newAddress)
+      await batchInitializer.batchLinkAddresses(currentAddresses, newAddresses, { from: admin }).should.be.fulfilled
+      let i = 0
+      for (let link of testLinks.slice(0, numlinks)) {
+        i++
+        const linkIdA = await registryLogic.linkIds.call(link.currentAddress)
+        linkIdA.should.be.bignumber.greaterThan(0)
+        linkIdA.should.be.bignumber.equal(new BigNumber(i))
+        const linkIdB = await registryLogic.linkIds.call(link.newAddress)
+        linkIdB.should.be.bignumber.equal(linkIdA)
+      }
+    })
+
+    it("Fails if initialization ended", async () => {
+      const numlinks = 50
+      const currentAddresses = testLinks.slice(0, numlinks).map(a => a.currentAddress)
+      const newAddresses = testLinks.slice(0, numlinks).map(a => a.newAddress)
+      await batchInitializer.endInitialization(registryLogic.address, {from: owner}).should.be.fulfilled
+      await batchInitializer.batchLinkAddresses(currentAddresses, newAddresses, { from: admin }).should.be.rejectedWith(EVMThrow)
+    })
+
+    it("Fails if lengths of args are not equal", async () => {
+      const numlinks = 50
+      const currentAddresses = testLinks.slice(0, numlinks).map(a => a.currentAddress)
+      const newAddresses = testLinks.slice(0, numlinks - 1).map(a => a.newAddress)
+      await batchInitializer.batchLinkAddresses(currentAddresses, newAddresses, { from: admin }).should.be.rejectedWith(EVMThrow)
+    })
+
+    it("Fails if lengths of args are not equal", async () => {
+      const numlinks = 50
+      const currentAddresses = testLinks.slice(0, numlinks - 1).map(a => a.currentAddress)
+      const newAddresses = testLinks.slice(0, numlinks).map(a => a.newAddress)
+      await batchInitializer.batchLinkAddresses(currentAddresses, newAddresses, { from: admin }).should.be.rejectedWith(EVMThrow)
+    })
+
+    it("Does note allow anyone else to batch load", async () => {
+      const numlinks = 50
+      const currentAddresses = testLinks.slice(0, numlinks).map(a => a.currentAddress)
+      const newAddresses = testLinks.slice(0, numlinks).map(a => a.newAddress)
+      await batchInitializer.batchLinkAddresses(currentAddresses, newAddresses, { from: unrelated }).should.be.rejectedWith(EVMThrow)
+    })
+
+    interface LinkSkippedArgs {
+      currentAddress: string
+      newAddress: string
+    }
+
+    it("emits and event if it skips already created accounts", async () => {
+      let numlinks = 5
+      let currentAddresses = testLinks.slice(0, numlinks).map(a => a.currentAddress)
+      let newAddresses = testLinks.slice(0, numlinks).map(a => a.newAddress)
+      await batchInitializer.batchLinkAddresses(currentAddresses, newAddresses, { from: admin }).should.be.fulfilled
+      numlinks = 10
+      currentAddresses = testLinks.slice(0, numlinks).map(a => a.currentAddress)
+      newAddresses = testLinks.slice(0, numlinks).map(a => a.newAddress)
+      const { logs } = ((await batchInitializer.batchLinkAddresses(currentAddresses, newAddresses, { from: admin })) as Web3.TransactionReceipt<
+        any
+      >) as Web3.TransactionReceipt<LinkSkippedArgs>
+
+      const matchingLog = logs.find(log => log.event === "linkSkipped")
+
+      should.exist(matchingLog)
+
+      logs.length.should.be.equal(5)
+      console.log(matchingLog)
+    })
+  })
+  describe("Batch loading attestations", async () => {
+    it("allows the admin to batch load attestations", async () => {
+      const numAttestations = 250
+      const requesters = testAttestations.slice(0, numAttestations).map(a => a.requester)
+      const attesters = testAttestations.slice(0, numAttestations).map(a => a.attester)
+      const subjects = testAttestations.slice(0, numAttestations).map(a => a.subject)
+      const dataHashes = testAttestations.slice(0, numAttestations).map(a => a.dataHash)
+      await batchInitializer.batchMigrateAttestations(requesters, attesters, subjects, dataHashes, { from: admin }).should.be.fulfilled
+    })
+    it("Fails if initialization ended", async () => {
+      const numAttestations = 250
+      const requesters = testAttestations.slice(0, numAttestations).map(a => a.requester)
+      const attesters = testAttestations.slice(0, numAttestations).map(a => a.attester)
+      const subjects = testAttestations.slice(0, numAttestations).map(a => a.subject)
+      const dataHashes = testAttestations.slice(0, numAttestations).map(a => a.dataHash)
+      await batchInitializer.endInitialization(attestationLogic.address, {from: owner}).should.be.fulfilled
+      await batchInitializer.batchMigrateAttestations(requesters, attesters, subjects, dataHashes, { from: admin }).should.be.rejectedWith(EVMThrow)
+    })
+
+    it("Fails if lengths of args not equal", async () => {
+      const numAttestations = 250
+      const requesters = testAttestations.slice(0, numAttestations - 1).map(a => a.requester)
+      const attesters = testAttestations.slice(0, numAttestations).map(a => a.attester)
+      const subjects = testAttestations.slice(0, numAttestations).map(a => a.subject)
+      const dataHashes = testAttestations.slice(0, numAttestations).map(a => a.dataHash)
+      await batchInitializer.batchMigrateAttestations(requesters, attesters, subjects, dataHashes, { from: admin }).should.be.rejectedWith(EVMThrow)
+    })
+
+    it("Fails if lengths of args not equal", async () => {
+      const numAttestations = 250
+      const requesters = testAttestations.slice(0, numAttestations).map(a => a.requester)
+      const attesters = testAttestations.slice(0, numAttestations - 1).map(a => a.attester)
+      const subjects = testAttestations.slice(0, numAttestations).map(a => a.subject)
+      const dataHashes = testAttestations.slice(0, numAttestations).map(a => a.dataHash)
+      await batchInitializer.batchMigrateAttestations(requesters, attesters, subjects, dataHashes, { from: admin }).should.be.rejectedWith(EVMThrow)
+    })
+
+    it("Fails if lengths of args not equal", async () => {
+      const numAttestations = 250
+      const requesters = testAttestations.slice(0, numAttestations).map(a => a.requester)
+      const attesters = testAttestations.slice(0, numAttestations).map(a => a.attester)
+      const subjects = testAttestations.slice(0, numAttestations - 1).map(a => a.subject)
+      const dataHashes = testAttestations.slice(0, numAttestations).map(a => a.dataHash)
+      await batchInitializer.batchMigrateAttestations(requesters, attesters, subjects, dataHashes, { from: admin }).should.be.rejectedWith(EVMThrow)
+    })
+
+    it("Fails if lengths of args not equal", async () => {
+      const numAttestations = 250
+      const requesters = testAttestations.slice(0, numAttestations).map(a => a.requester)
+      const attesters = testAttestations.slice(0, numAttestations).map(a => a.attester)
+      const subjects = testAttestations.slice(0, numAttestations).map(a => a.subject)
+      const dataHashes = testAttestations.slice(0, numAttestations - 1).map(a => a.dataHash)
+      await batchInitializer.batchMigrateAttestations(requesters, attesters, subjects, dataHashes, { from: admin }).should.be.rejectedWith(EVMThrow)
+    })
+
+    it("Fails if lengths of args not equal", async () => {
+      const numAttestations = 250
+      const requesters = testAttestations.slice(0, numAttestations).map(a => a.requester)
+      const attesters = testAttestations.slice(0, numAttestations - 3).map(a => a.attester)
+      const subjects = testAttestations.slice(0, numAttestations - 2).map(a => a.subject)
+      const dataHashes = testAttestations.slice(0, numAttestations - 1).map(a => a.dataHash)
+      await batchInitializer.batchMigrateAttestations(requesters, attesters, subjects, dataHashes, { from: admin }).should.be.rejectedWith(EVMThrow)
+    })
+
+    it("Does note allow anyone else to batch load", async () => {
+      const numAttestations = 50
+      const requesters = testAttestations.slice(0, numAttestations).map(a => a.requester)
+      const attesters = testAttestations.slice(0, numAttestations).map(a => a.attester)
+      const subjects = testAttestations.slice(0, numAttestations).map(a => a.subject)
+      const dataHashes = testAttestations.slice(0, numAttestations).map(a => a.dataHash)
+      await batchInitializer
+        .batchMigrateAttestations(requesters, attesters, subjects, dataHashes, { from: unrelated })
+        .should.be.rejectedWith(EVMThrow)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,16 @@
 # yarn lockfile v1
 
 
-"@bloomprotocol/attestations-lib@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@bloomprotocol/attestations-lib/-/attestations-lib-0.4.3.tgz#c5c6691c8e3c29f081c5b2ad48ed435baa95df93"
+"@bloomprotocol/attestations-lib@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@bloomprotocol/attestations-lib/-/attestations-lib-3.0.2.tgz#9c2cd0e9cefd7c4c1c42a902be92413418fbd9c1"
   dependencies:
-    "@types/lodash" "^4.14.116"
+    eth-sig-util "^2.1.0"
+    ethereumjs-util "^6.0.0"
     js-sha3 "^0.8.0"
-    lodash "^4.17.10"
     merkletreejs "^0.0.11"
     ts-node "^7.0.1"
     tsconfig-paths "^3.5.0"
-    uuidv4 "^1.0.1"
     web3-utils "^1.0.0-beta.36"
 
 "@ledgerhq/hw-app-eth@^4.2.0":
@@ -82,10 +81,6 @@
 "@types/lodash@^4.14.105":
   version "4.14.105"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.105.tgz#9fcc4627a1f98f8f8fce79ddb2bff4afd97e959b"
-
-"@types/lodash@^4.14.116":
-  version "4.14.116"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
 
 "@types/mocha@^2.2.44":
   version "2.2.48"
@@ -1465,6 +1460,13 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+buffer@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -2696,6 +2698,17 @@ eth-sig-util@^2.0.1:
     ethereumjs-abi "git+https://github.com/ethereumjs/ethereumjs-abi.git"
     ethereumjs-util "^5.1.1"
 
+eth-sig-util@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-2.1.0.tgz#33e60e5486897a2ddeb4bf5a0993b2c6d5cc9e19"
+  dependencies:
+    buffer "^5.2.1"
+    elliptic "^6.4.0"
+    ethereumjs-abi "0.6.5"
+    ethereumjs-util "^5.1.1"
+    tweetnacl "^1.0.0"
+    tweetnacl-util "^0.15.0"
+
 ethereum-common@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ethereum-common/-/ethereum-common-0.2.0.tgz#13bf966131cce1eeade62a1b434249bb4cb120ca"
@@ -2704,7 +2717,7 @@ ethereum-common@^0.0.18:
   version "0.0.18"
   resolved "https://registry.yarnpkg.com/ethereum-common/-/ethereum-common-0.0.18.tgz#2fdc3576f232903358976eb39da783213ff9523f"
 
-ethereumjs-abi@^0.6.5, "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
+ethereumjs-abi@0.6.5, ethereumjs-abi@^0.6.5, "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.5"
   resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf"
   dependencies:
@@ -2763,6 +2776,18 @@ ethereumjs-util@^5.0.0, ethereumjs-util@^5.0.1, ethereumjs-util@^5.1.1, ethereum
     safe-buffer "^5.1.1"
     secp256k1 "^3.0.1"
 
+ethereumjs-util@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.0.0.tgz#f14841c182b918615afefd744207c7932c8536c0"
+  dependencies:
+    bn.js "^4.11.0"
+    create-hash "^1.1.2"
+    ethjs-util "^0.1.6"
+    keccak "^1.0.2"
+    rlp "^2.0.0"
+    safe-buffer "^5.1.1"
+    secp256k1 "^3.0.1"
+
 ethereumjs-vm@^2.0.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/ethereumjs-vm/-/ethereumjs-vm-2.3.3.tgz#05719139e0c4a59e829022964a6048b17d2d84b0"
@@ -2809,6 +2834,13 @@ ethjs-unit@0.1.6:
 ethjs-util@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.4.tgz#1c8b6879257444ef4d3f3fbbac2ded12cd997d93"
+  dependencies:
+    is-hex-prefixed "1.0.0"
+    strip-hex-prefix "1.0.0"
+
+ethjs-util@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
   dependencies:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
@@ -7365,9 +7397,17 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+tweetnacl-util@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.0.tgz#4576c1cee5e2d63d207fee52f1ba02819480bc75"
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+
+tweetnacl@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.0.tgz#713d8b818da42068740bf68386d0479e66fc8a7b"
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -7540,26 +7580,19 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
-uuid@3.2.1, uuid@^3.0.0, uuid@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
-
 uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
+
+uuid@^3.0.0, uuid@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
 uuidv4@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/uuidv4/-/uuidv4-1.0.0.tgz#f30a2e10f65b2381fb9a577681337efb17eb484f"
   dependencies:
     sha-1 "0.1.1"
-
-uuidv4@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/uuidv4/-/uuidv4-1.0.1.tgz#0a670756781674480a7c4d00df4a8d1963ea4745"
-  dependencies:
-    sha-1 "0.1.1"
-    uuid "3.2.1"
 
 v8-compile-cache@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
An admin can use batchInitializer to migrate data to initializable contracts only during the initialization period.
