### PR TITLE
contract migration helpers

### DIFF
--- a/ts_test/helpers/batchMigrateAttestations.ts
+++ b/ts_test/helpers/batchMigrateAttestations.ts
@@ -1,0 +1,45 @@
+interface IParsedData {
+  requesters: string[]
+  attesters: string[]
+  subjects: string[]
+  dataHashes: string[]
+}
+
+export const batchMigrateAttestations = async (
+  func: any,
+  data: IParsedData,
+  options: {
+    startingNonce: number
+    gasPrice: number
+    gas: number
+    from: string
+    chunkSize: number
+  }
+) => {
+  let nonce = options.startingNonce
+  for (let i = 0, j = data.requesters.length, p = Promise.resolve({}); i < j; i += options.chunkSize) {
+    p = p.then(
+      _ =>
+        new Promise(resolve => {
+          console.log(nonce.toString())
+          let dataChunk: any = [
+            data.requesters.slice(i, i + options.chunkSize),
+            data.attesters.slice(i, i + options.chunkSize),
+            data.subjects.slice(i, i + options.chunkSize),
+            data.dataHashes.slice(i, i + options.chunkSize)
+          ]
+          dataChunk.push({
+            nonce: nonce,
+            gasPrice: options.gasPrice,
+            gas: options.gas,
+            from: options.from
+          })
+          func.sendTransaction.apply(null, dataChunk).then((txHash: string) => {
+            console.log(txHash)
+            nonce++
+            resolve()
+          })
+        })
+    )
+  }
+}

--- a/ts_test/helpers/parseBatchAttestations.ts
+++ b/ts_test/helpers/parseBatchAttestations.ts
@@ -1,0 +1,23 @@
+const fs = require("fs")
+interface IAttestation {
+  requester: string
+  attester: string
+  subject: string
+  dataHash: string
+}
+export const parseBatchAttestations = async (filePath: string) => {
+  const fileContents = fs.readFileSync(filePath)
+  const lines = fileContents.toString().split("\n")
+  const firstLine = lines[0]
+  const dataLines = lines.slice(1, lines.length - 1)
+  const dataParsed: IAttestation[] = dataLines.map((line: string) =>
+    firstLine.split(",").reduce((curr: any, next: any, index: any) => ({ ...curr, [next]: line.split(",")[index] }), {})
+  )
+  const dataFormatted = {
+    requesters: dataParsed.map(a => a.requester),
+    attesters: dataParsed.map(a => a.attester),
+    subjects: dataParsed.map(a => a.subject),
+    dataHashes: dataParsed.map(a => a.dataHash),
+  }
+  return dataFormatted
+}


### PR DESCRIPTION
This should have been merged back when we deployed the trustless contracts. Just some helper functions for batch loading